### PR TITLE
(IAC-594) node_pools items can now add in n number of misc disks

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -491,6 +491,12 @@ The following items **MUST** be added to your `ansible-vars.yaml` file if you ar
 
 ### Ingress Controller
 INGRESS_NGINX_CONFIG:
+  controller:
+    service:
+      externalTrafficPolicy: Cluster
+      # loadBalancerIP: <your static ip> # Assigns a specific IP for your loadBalancer
+      loadBalancerSourceRanges: [] # Not supported on open source kubernetes
+      annotations:
 
 ### Metrics Server
 METRICS_SERVER_CHART_VERSION: 5.10.14

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -181,7 +181,7 @@ node_pools = {
     count       = 3
     cpus        = 2
     memory      = 4096
-    disk        = 100
+    os_disk     = 100
     node_taints = []
     node_labels = {}
   },
@@ -192,7 +192,7 @@ node_pools = {
     count       = 1
     cpus        = 8
     memory      = 16384
-    disk        = 100
+    os_disk     = 100
     node_taints = []
     node_labels = {
       "kubernetes.azure.com/mode" = "system" # REQUIRED LABEL - DO NOT REMOVE
@@ -202,7 +202,11 @@ node_pools = {
     count       = 3
     cpus        = 16
     memory      = 131072
-    disk        = 350
+    os_disk     = 350
+    misc_disks  = [
+      150,
+      150,
+    ]
     node_taints = ["workload.sas.com/class=cas:NoSchedule"]
     node_labels = {
       "workload.sas.com/class" = "cas"
@@ -212,7 +216,7 @@ node_pools = {
     count       = 1
     cpus        = 16
     memory      = 131072
-    disk        = 100
+    os_disk     = 100
     node_taints = ["workload.sas.com/class=compute:NoSchedule"]
     node_labels = {
       "workload.sas.com/class"        = "compute"
@@ -223,7 +227,10 @@ node_pools = {
     count       = 1
     cpus        = 8
     memory      = 32768
-    disk        = 100
+    os_disk     = 100
+    misc_disks  = [
+      150,
+    ]
     node_taints = ["workload.sas.com/class=stateful:NoSchedule"]
     node_labels = {
       "workload.sas.com/class" = "stateful"
@@ -233,7 +240,10 @@ node_pools = {
     count       = 2
     cpus        = 8
     memory      = 32768
-    disk        = 100
+    os_disk     = 100
+    misc_disks  = [
+      150,
+    ]
     node_taints = ["workload.sas.com/class=stateless:NoSchedule"]
     node_labels = {
       "workload.sas.com/class" = "stateless"

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -129,14 +129,14 @@ node_pools = {
 create_jump       = true          # Creation flag
 jump_num_cpu      = 4             # 4 CPUs
 jump_memory       = 8092          # 8 GB
-jump_disk_size = 100           # 100 GB
+jump_disk_size    = 100           # 100 GB
 jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
 create_nfs       = true          # Creation flag
 nfs_num_cpu      = 8             # 8 CPUs
 nfs_memory       = 16384         # 16 GB
-nfs_disk_size = 500           # 500 GB
+nfs_disk_size    = 500           # 500 GB
 nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -1,9 +1,9 @@
 # General items
 ansible_user     = ""
 ansible_password = ""
-prefix           = "v4-k8s-min" # Infra prefix
-gateway          = ""           # Gateway for servers
-netmask          = ""           # Needed for any network outside the 10.12.0 location
+prefix           = "v4-k8s-dhcp" # Infra prefix
+gateway          = ""            # Gateway for servers
+netmask          = ""            # Needed for any network outside the 10.12.0 location
 
 # vSphere
 vsphere_server        = "" # Name of the vSphere server
@@ -49,15 +49,14 @@ control_plane_ssh_key_name = "cp_ssh"
 #                     These are typically: compute, stateful, and
 #                     stateless. 
 #
-cluster_node_pool_mode = "minimal"
 node_pools = {
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
   #                      Other varaibles may be altered
   control_plane = {
-    count       = 1
+    count       = 3
     cpus        = 2
     memory      = 4096
-    disk        = 100
+    os_disk     = 100
     node_taints = []
     node_labels = {}
   },
@@ -67,17 +66,17 @@ node_pools = {
     count       = 1
     cpus        = 8
     memory      = 16384
-    disk        = 100
+    os_disk     = 100
     node_taints = []
     node_labels = {
       "kubernetes.azure.com/mode" = "system" # REQUIRED LABEL - DO NOT REMOVE
     }
   },
   cas = {
-    count  = 3
-    cpus   = 8
-    memory = 16384
-    disk   = 100
+    count   = 3
+    cpus    = 16
+    memory  = 131072
+    os_disk = 350
     misc_disks = [
       150,
       150,
@@ -87,42 +86,65 @@ node_pools = {
       "workload.sas.com/class" = "cas"
     }
   },
-  generic = {
-    count  = 5
-    cpus   = 24 # 16
-    memory = 131072
-    disk   = 350 # 250
-    misc_disks = [
-      150,
-    ]
-    node_taints = []
+  compute = {
+    count       = 1
+    cpus        = 16
+    memory      = 131072
+    os_disk     = 100
+    node_taints = ["workload.sas.com/class=compute:NoSchedule"]
     node_labels = {
       "workload.sas.com/class"        = "compute"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
+    }
+  },
+  stateful = {
+    count   = 1
+    cpus    = 8
+    memory  = 32768
+    os_disk = 100
+    misc_disks = [
+      150,
+    ]
+    node_taints = ["workload.sas.com/class=stateful:NoSchedule"]
+    node_labels = {
+      "workload.sas.com/class" = "stateful"
+    }
+  },
+  stateless = {
+    count   = 2
+    cpus    = 8
+    memory  = 32768
+    os_disk = 100
+    misc_disks = [
+      150,
+    ]
+    node_taints = ["workload.sas.com/class=stateless:NoSchedule"]
+    node_labels = {
+      "workload.sas.com/class" = "stateless"
     }
   }
 }
 
 # Jump server
-create_jump    = true          # Creation flag
-jump_num_cpu   = 4             # 4 CPUs
-jump_memory    = 8092          # 8 GB
-jump_disk_size = 100           # 100 GB
-jump_ip        = "10.12.50.30" # Assigned values for static IPs
+create_jump       = true          # Creation flag
+jump_num_cpu      = 4             # 4 CPUs
+jump_memory       = 8092          # 8 GB
+jump_os_disk_size = 100           # 100 GB
+jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
-create_nfs    = true          # Creation flag
-nfs_num_cpu   = 8             # 8 CPUs
-nfs_memory    = 16384         # 16 GB
-nfs_disk_size = 500           # 500 GB
-nfs_ip        = "10.12.50.31" # Assigned values for static IPs
+create_nfs       = true          # Creation flag
+nfs_num_cpu      = 8             # 8 CPUs
+nfs_memory       = 16384         # 16 GB
+nfs_os_disk_size = 500           # 500 GB
+nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers
 postgres_servers = {
   default = {
     server_num_cpu         = 8                       # 8 CPUs
     server_memory          = 16384                   # 16 GB
-    server_disk_size       = 250                     # 256 GB
+    server_os_disk_size    = 250                     # 256 GB
     server_ip              = "10.12.50.32"           # Assigned values for static IPs
     server_version         = 12                      # PostgreSQL version
     server_ssl             = "off"                   # SSL flag

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -129,14 +129,14 @@ node_pools = {
 create_jump       = true          # Creation flag
 jump_num_cpu      = 4             # 4 CPUs
 jump_memory       = 8092          # 8 GB
-jump_os_disk_size = 100           # 100 GB
+jump_disk_size = 100           # 100 GB
 jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
 create_nfs       = true          # Creation flag
 nfs_num_cpu      = 8             # 8 CPUs
 nfs_memory       = 16384         # 16 GB
-nfs_os_disk_size = 500           # 500 GB
+nfs_disk_size = 500           # 500 GB
 nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -126,25 +126,25 @@ node_pools = {
 }
 
 # Jump server
-create_jump       = true          # Creation flag
-jump_num_cpu      = 4             # 4 CPUs
-jump_memory       = 8092          # 8 GB
-jump_disk_size    = 100           # 100 GB
-jump_ip           = "10.12.50.30" # Assigned values for static IPs
+create_jump    = true          # Creation flag
+jump_num_cpu   = 4             # 4 CPUs
+jump_memory    = 8092          # 8 GB
+jump_disk_size = 100           # 100 GB
+jump_ip        = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
-create_nfs       = true          # Creation flag
-nfs_num_cpu      = 8             # 8 CPUs
-nfs_memory       = 16384         # 16 GB
-nfs_disk_size    = 500           # 500 GB
-nfs_ip           = "10.12.50.31" # Assigned values for static IPs
+create_nfs    = true          # Creation flag
+nfs_num_cpu   = 8             # 8 CPUs
+nfs_memory    = 16384         # 16 GB
+nfs_disk_size = 500           # 500 GB
+nfs_ip        = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers
 postgres_servers = {
   default = {
     server_num_cpu         = 8                       # 8 CPUs
     server_memory          = 16384                   # 16 GB
-    server_os_disk_size    = 250                     # 256 GB
+    server_disk_size       = 250                     # 256 GB
     server_ip              = "10.12.50.32"           # Assigned values for static IPs
     server_version         = 12                      # PostgreSQL version
     server_ssl             = "off"                   # SSL flag

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -57,7 +57,7 @@ node_pools = {
     count       = 1
     cpus        = 2
     memory      = 4096
-    disk        = 100
+    os_disk     = 100
     node_taints = []
     node_labels = {}
   },
@@ -67,17 +67,17 @@ node_pools = {
     count       = 1
     cpus        = 8
     memory      = 16384
-    disk        = 100
+    os_disk     = 100
     node_taints = []
     node_labels = {
       "kubernetes.azure.com/mode" = "system" # REQUIRED LABEL - DO NOT REMOVE
     }
   },
   cas = {
-    count  = 3
-    cpus   = 8
-    memory = 16384
-    disk   = 100
+    count   = 3
+    cpus    = 8
+    memory  = 16384
+    os_disk = 100
     misc_disks = [
       150,
       150,
@@ -88,10 +88,10 @@ node_pools = {
     }
   },
   generic = {
-    count  = 5
-    cpus   = 24 # 16
-    memory = 131072
-    disk   = 350 # 250
+    count   = 5
+    cpus    = 24
+    memory  = 131072
+    os_disk = 350
     misc_disks = [
       150,
     ]

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -143,25 +143,25 @@ node_pools = {
 }
 
 # Jump server
-create_jump       = true          # Creation flag
-jump_num_cpu      = 4             # 4 CPUs
-jump_memory       = 8092          # 8 GB
-jump_disk_size    = 100           # 100 GB
-jump_ip           = "10.12.50.30" # Assigned values for static IPs
+create_jump    = true          # Creation flag
+jump_num_cpu   = 4             # 4 CPUs
+jump_memory    = 8092          # 8 GB
+jump_disk_size = 100           # 100 GB
+jump_ip        = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
-create_nfs       = true          # Creation flag
-nfs_num_cpu      = 8             # 8 CPUs
-nfs_memory       = 16384         # 16 GB
-nfs_disk_size    = 500           # 500 GB
-nfs_ip           = "10.12.50.31" # Assigned values for static IPs
+create_nfs    = true          # Creation flag
+nfs_num_cpu   = 8             # 8 CPUs
+nfs_memory    = 16384         # 16 GB
+nfs_disk_size = 500           # 500 GB
+nfs_ip        = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers
 postgres_servers = {
   default = {
     server_num_cpu         = 8                       # 8 CPUs
     server_memory          = 16384                   # 16 GB
-    server_os_disk_size    = 250                     # 256 GB
+    server_disk_size       = 250                     # 256 GB
     server_ip              = "10.12.50.32"           # Assigned values for static IPs
     server_version         = 12                      # PostgreSQL version
     server_ssl             = "off"                   # SSL flag

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -146,14 +146,14 @@ node_pools = {
 create_jump       = true          # Creation flag
 jump_num_cpu      = 4             # 4 CPUs
 jump_memory       = 8092          # 8 GB
-jump_disk_size = 100           # 100 GB
+jump_disk_size    = 100           # 100 GB
 jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
 create_nfs       = true          # Creation flag
 nfs_num_cpu      = 8             # 8 CPUs
 nfs_memory       = 16384         # 16 GB
-nfs_disk_size = 500           # 500 GB
+nfs_disk_size    = 500           # 500 GB
 nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -1,9 +1,9 @@
 # General items
 ansible_user     = ""
 ansible_password = ""
-prefix           = "viya4-k8s" # Infra prefix
-gateway          = ""          # Gateway for servers
-netmask          = ""          # Needed for any network outside the 10.12.0 location
+prefix           = "v4-k8s-static" # Infra prefix
+gateway          = ""              # Gateway for servers
+netmask          = ""              # Needed for any network outside the 10.12.0 location
 
 # vSphere
 vsphere_server        = "" # Name of the vSphere server
@@ -53,40 +53,56 @@ node_pools = {
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
   #                      Other varaibles may be altered
   control_plane = {
-    count       = 3
-    cpus        = 2
-    memory      = 4096
-    disk        = 100
+    cpus    = 2
+    memory  = 4096
+    os_disk = 100
+    ip_addresses = [
+      "",
+      "",
+      "",
+    ]
     node_taints = []
     node_labels = {}
   },
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
   #                      Other varaibles may be altered
   system = {
-    count       = 1
-    cpus        = 8
-    memory      = 16384
-    disk        = 100
+    cpus    = 8
+    memory  = 16384
+    os_disk = 100
+    ip_addresses = [
+      "",
+    ]
     node_taints = []
     node_labels = {
       "kubernetes.azure.com/mode" = "system" # REQUIRED LABEL - DO NOT REMOVE
     }
   },
   cas = {
-    count       = 3
-    cpus        = 16
-    memory      = 131072
-    disk        = 350
+    cpus    = 16
+    memory  = 131072
+    os_disk = 350
+    misc_disks = [
+      150,
+      150,
+    ]
+    ip_addresses = [
+      "",
+      "",
+      "",
+    ]
     node_taints = ["workload.sas.com/class=cas:NoSchedule"]
     node_labels = {
       "workload.sas.com/class" = "cas"
     }
   },
   compute = {
-    count       = 1
-    cpus        = 16
-    memory      = 131072
-    disk        = 100
+    cpus    = 16
+    memory  = 131072
+    os_disk = 100
+    ip_addresses = [
+      "",
+    ]
     node_taints = ["workload.sas.com/class=compute:NoSchedule"]
     node_labels = {
       "workload.sas.com/class"        = "compute"
@@ -94,20 +110,31 @@ node_pools = {
     }
   },
   stateful = {
-    count       = 1
-    cpus        = 8
-    memory      = 32768
-    disk        = 100
+    cpus    = 8
+    memory  = 32768
+    os_disk = 100
+    misc_disks = [
+      150,
+    ]
+    ip_addresses = [
+      "",
+    ]
     node_taints = ["workload.sas.com/class=stateful:NoSchedule"]
     node_labels = {
       "workload.sas.com/class" = "stateful"
     }
   },
   stateless = {
-    count       = 2
-    cpus        = 8
-    memory      = 32768
-    disk        = 100
+    cpus    = 8
+    memory  = 32768
+    os_disk = 100
+    misc_disks = [
+      150,
+    ]
+    ip_addresses = [
+      "",
+      "",
+    ]
     node_taints = ["workload.sas.com/class=stateless:NoSchedule"]
     node_labels = {
       "workload.sas.com/class" = "stateless"
@@ -116,25 +143,25 @@ node_pools = {
 }
 
 # Jump server
-create_jump    = true          # Creation flag
-jump_num_cpu   = 4             # 4 CPUs
-jump_memory    = 8092          # 8 GB
-jump_disk_size = 100           # 100 GB
-jump_ip        = "10.12.50.30" # Assigned values for static IPs
+create_jump       = true          # Creation flag
+jump_num_cpu      = 4             # 4 CPUs
+jump_memory       = 8092          # 8 GB
+jump_os_disk_size = 100           # 100 GB
+jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
-create_nfs    = true          # Creation flag
-nfs_num_cpu   = 8             # 8 CPUs
-nfs_memory    = 16384         # 16 GB
-nfs_disk_size = 500           # 500 GB
-nfs_ip        = "10.12.50.31" # Assigned values for static IPs
+create_nfs       = true          # Creation flag
+nfs_num_cpu      = 8             # 8 CPUs
+nfs_memory       = 16384         # 16 GB
+nfs_os_disk_size = 500           # 500 GB
+nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers
 postgres_servers = {
   default = {
     server_num_cpu         = 8                       # 8 CPUs
     server_memory          = 16384                   # 16 GB
-    server_disk_size       = 250                     # 256 GB
+    server_os_disk_size    = 250                     # 256 GB
     server_ip              = "10.12.50.32"           # Assigned values for static IPs
     server_version         = 12                      # PostgreSQL version
     server_ssl             = "off"                   # SSL flag

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -146,14 +146,14 @@ node_pools = {
 create_jump       = true          # Creation flag
 jump_num_cpu      = 4             # 4 CPUs
 jump_memory       = 8092          # 8 GB
-jump_os_disk_size = 100           # 100 GB
+jump_disk_size = 100           # 100 GB
 jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
 create_nfs       = true          # Creation flag
 nfs_num_cpu      = 8             # 8 CPUs
 nfs_memory       = 16384         # 16 GB
-nfs_os_disk_size = 500           # 500 GB
+nfs_disk_size = 500           # 500 GB
 nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -56,7 +56,7 @@ node_pools = {
     count       = 1
     cpus        = 2
     memory      = 4096
-    disk        = 100
+    os_disk     = 100
     node_taints = []
     node_labels = {}
   },
@@ -66,7 +66,7 @@ node_pools = {
     count       = 1
     cpus        = 8
     memory      = 16384
-    disk        = 100
+    os_disk     = 100
     node_taints = []
     node_labels = {
       "kubernetes.azure.com/mode" = "system" # REQUIRED LABEL - DO NOT REMOVE
@@ -76,7 +76,7 @@ node_pools = {
     count       = 3
     cpus        = 8
     memory      = 16384
-    disk        = 100
+    os_disk     = 100
     node_taints = ["workload.sas.com/class=cas:NoSchedule"]
     node_labels = {
       "workload.sas.com/class" = "cas"
@@ -84,9 +84,9 @@ node_pools = {
   },
   generic = {
     count       = 5
-    cpus        = 24 # 16
+    cpus        = 24
     memory      = 131072
-    disk        = 350 # 250
+    os_disk     = 350
     node_taints = []
     node_labels = {
       "workload.sas.com/class"        = "compute"
@@ -96,25 +96,25 @@ node_pools = {
 }
 
 # Jump server
-create_jump    = true          # Creation flag
-jump_num_cpu   = 4             # 4 CPUs
-jump_memory    = 8092          # 8 GB
-jump_disk_size = 100           # 100 GB
-jump_ip        = "10.12.50.30" # Assigned values for static IPs
+create_jump       = true          # Creation flag
+jump_num_cpu      = 4             # 4 CPUs
+jump_memory       = 8092          # 8 GB
+jump_os_disk_size = 100           # 100 GB
+jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
-create_nfs    = true          # Creation flag
-nfs_num_cpu   = 8             # 8 CPUs
-nfs_memory    = 16384         # 16 GB
-nfs_disk_size = 500           # 500 GB
-nfs_ip        = "10.12.50.31" # Assigned values for static IPs
+create_nfs       = true          # Creation flag
+nfs_num_cpu      = 8             # 8 CPUs
+nfs_memory       = 16384         # 16 GB
+nfs_os_disk_size = 500           # 500 GB
+nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers
 postgres_servers = {
   default = {
     server_num_cpu         = 8                       # 8 CPUs
     server_memory          = 16384                   # 16 GB
-    server_disk_size       = 250                     # 256 GB
+    server_os_disk_size    = 250                     # 256 GB
     server_ip              = "10.12.50.32"           # Assigned values for static IPs
     server_version         = 12                      # PostgreSQL version
     server_ssl             = "off"                   # SSL flag

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -96,25 +96,25 @@ node_pools = {
 }
 
 # Jump server
-create_jump       = true          # Creation flag
-jump_num_cpu      = 4             # 4 CPUs
-jump_memory       = 8092          # 8 GB
-jump_disk_size    = 100           # 100 GB
-jump_ip           = "10.12.50.30" # Assigned values for static IPs
+create_jump    = true          # Creation flag
+jump_num_cpu   = 4             # 4 CPUs
+jump_memory    = 8092          # 8 GB
+jump_disk_size = 100           # 100 GB
+jump_ip        = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
-create_nfs       = true          # Creation flag
-nfs_num_cpu      = 8             # 8 CPUs
-nfs_memory       = 16384         # 16 GB
-nfs_disk_size    = 500           # 500 GB
-nfs_ip           = "10.12.50.31" # Assigned values for static IPs
+create_nfs    = true          # Creation flag
+nfs_num_cpu   = 8             # 8 CPUs
+nfs_memory    = 16384         # 16 GB
+nfs_disk_size = 500           # 500 GB
+nfs_ip        = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers
 postgres_servers = {
   default = {
     server_num_cpu         = 8                       # 8 CPUs
     server_memory          = 16384                   # 16 GB
-    server_os_disk_size    = 250                     # 256 GB
+    server_disk_size       = 250                     # 256 GB
     server_ip              = "10.12.50.32"           # Assigned values for static IPs
     server_version         = 12                      # PostgreSQL version
     server_ssl             = "off"                   # SSL flag

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -99,14 +99,14 @@ node_pools = {
 create_jump       = true          # Creation flag
 jump_num_cpu      = 4             # 4 CPUs
 jump_memory       = 8092          # 8 GB
-jump_disk_size = 100           # 100 GB
+jump_disk_size    = 100           # 100 GB
 jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
 create_nfs       = true          # Creation flag
 nfs_num_cpu      = 8             # 8 CPUs
 nfs_memory       = 16384         # 16 GB
-nfs_disk_size = 500           # 500 GB
+nfs_disk_size    = 500           # 500 GB
 nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -99,14 +99,14 @@ node_pools = {
 create_jump       = true          # Creation flag
 jump_num_cpu      = 4             # 4 CPUs
 jump_memory       = 8092          # 8 GB
-jump_os_disk_size = 100           # 100 GB
+jump_disk_size = 100           # 100 GB
 jump_ip           = "10.12.50.30" # Assigned values for static IPs
 
 # NFS server
 create_nfs       = true          # Creation flag
 nfs_num_cpu      = 8             # 8 CPUs
 nfs_memory       = 16384         # 16 GB
-nfs_os_disk_size = 500           # 500 GB
+nfs_disk_size = 500           # 500 GB
 nfs_ip           = "10.12.50.31" # Assigned values for static IPs
 
 # Postgres Servers

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,8 @@ module "control_plane" {
   instance_count   = length(each.value.ip_addresses) != 0 ? length(each.value.ip_addresses) : each.value.count
   num_cpu          = each.value.cpus
   memory           = each.value.memory
-  disk_size        = each.value.disk
+  disk_size        = each.value.os_disk
+  misc_disks       = each.value.misc_disks
   ip_addresses     = length(each.value.ip_addresses) != 0 ? each.value.ip_addresses : []
 
 }
@@ -56,7 +57,8 @@ module "system" {
   instance_count   = length(each.value.ip_addresses) != 0 ? length(each.value.ip_addresses) : each.value.count
   num_cpu          = each.value.cpus
   memory           = each.value.memory
-  disk_size        = each.value.disk
+  disk_size        = each.value.os_disk
+  misc_disks       = each.value.misc_disks
   ip_addresses     = length(each.value.ip_addresses) != 0 ? each.value.ip_addresses : []
 
 }
@@ -82,7 +84,8 @@ module "node" {
   instance_count   = length(each.value.ip_addresses) != 0 ? length(each.value.ip_addresses) : each.value.count
   num_cpu          = each.value.cpus
   memory           = each.value.memory
-  disk_size        = each.value.disk
+  disk_size        = each.value.os_disk
+  misc_disks       = each.value.misc_disks
   ip_addresses     = length(each.value.ip_addresses) != 0 ? each.value.ip_addresses : []
 
 }
@@ -131,6 +134,28 @@ module "nfs" {
   dns_servers      = var.dns_servers
 }
 
+module "cr" {
+  source = "./modules/vm"
+
+  name             = "cr"
+  instance_count   = var.create_cr ? 1 : 0
+  resource_pool_id = data.vsphere_resource_pool.pool.id
+  folder           = var.vsphere_folder
+  datastore        = var.vsphere_datastore
+  network          = var.vsphere_network
+  datacenter_id    = data.vsphere_datacenter.dc.id
+  template         = var.vsphere_template
+  cluster_domain   = var.cluster_domain
+  cluster_name     = local.cluster_name
+  ip_addresses     = [var.cr_ip]
+  memory           = var.cr_memory
+  num_cpu          = var.cr_num_cpu
+  disk_size        = var.cr_disk_size
+  netmask          = var.netmask
+  gateway          = var.gateway
+  dns_servers      = var.dns_servers
+}
+
 module "postgresql" {
   source = "./modules/server"
 
@@ -162,6 +187,7 @@ resource "local_file" "inventory" {
     node_ips          = length(local.node_ips) > 0 ? local.node_ips : []
     nfs_ip            = var.create_nfs ? var.nfs_ip : null
     jump_ip           = var.create_jump ? var.jump_ip : null
+    cr_ip             = var.create_cr ? var.cr_ip : null
     postgres_servers  = local.postgres_servers
     }
   )
@@ -189,6 +215,7 @@ resource "local_file" "ansible_vars" {
     kube_vip_range             = var.kube_vip_range
     nfs_ip                     = var.create_nfs ? var.nfs_ip : null
     jump_ip                    = var.create_jump ? var.jump_ip : null
+    cr_ip                      = var.create_cr ? var.cr_ip : null
     system_ssh_keys_dir        = var.system_ssh_keys_dir
     node_labels                = local.node_labels
     node_taints                = local.node_taints

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -38,9 +38,22 @@ resource "vsphere_virtual_machine" "static" {
   }
 
   disk {
-    label            = "disk0"
+    label            = "os-disk-01"
     size             = var.disk_size
     thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
+    unit_number      = 0
+  }
+  dynamic "disk" {
+    # for_each = var.misc_disks != null ? length(var.misc_disks) > 0 ? var.misc_disks : [] : []
+    for_each = var.misc_disks != null ? length(var.misc_disks) > 0 ? { for k, v in var.misc_disks : k => v } : {} : {}
+    content {
+      # label            = "misc-disk-${index(var.misc_disks, disk.value) + 1}"
+      label            = format("misc-disk-%02d", disk.key + 1)
+      size             = disk.value
+      thin_provisioned = true
+      # unit_number      = index(var.misc_disks, disk.value) + 1
+      unit_number = disk.key + 1
+    }
   }
 
   clone {

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -62,6 +62,11 @@ variable "disk_size" {
   type = string
 }
 
+variable "misc_disks" {
+  type    = list(any)
+  default = null
+}
+
 variable "dns_servers" {
   type = list(any)
 }

--- a/playbooks/kubernetes-install.yaml
+++ b/playbooks/kubernetes-install.yaml
@@ -81,6 +81,7 @@
 # Setup default storage class for cluster
 - hosts: localhost
   roles:
+    - { role: kubernetes/storage/sig-storage-local-static-provisioner }
     - { role: kubernetes/storage/nfs-subdir-external-provisioner }
 
 # Misc cluster related items

--- a/roles/kubernetes/control_plane/init/primary/templates/kubeadm-config.j2
+++ b/roles/kubernetes/control_plane/init/primary/templates/kubeadm-config.j2
@@ -34,11 +34,11 @@ networking:
   podSubnet: "{{ kubernetes_pod_subnet }}"
 apiServerExtraArgs:
   service-node-port-range: 80-32767
-  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"
+  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true,BlockVolume=true"
 controllerManagerExtraArgs:
-  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"
+  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true,BlockVolume=true"
 schedulerExtraArgs:
-  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"
+  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true,BlockVolume=true"
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/roles/kubernetes/control_plane/init/primary/templates/kubeadm-config.j2
+++ b/roles/kubernetes/control_plane/init/primary/templates/kubeadm-config.j2
@@ -26,20 +26,6 @@ networking:
   podSubnet: "{{ kubernetes_pod_subnet }}"
 clusterName: "{{ kubernetes_cluster_name }}"
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: MasterConfiguration
-api:
-  advertiseAddress: "{{ kubernetes_vip_ip }}"
-networking:
-  podSubnet: "{{ kubernetes_pod_subnet }}"
-apiServerExtraArgs:
-  service-node-port-range: 80-32767
-  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true,BlockVolume=true"
-controllerManagerExtraArgs:
-  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true,BlockVolume=true"
-schedulerExtraArgs:
-  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true,BlockVolume=true"
----
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 authentication:

--- a/roles/kubernetes/node/baseline/tasks/main.yaml
+++ b/roles/kubernetes/node/baseline/tasks/main.yaml
@@ -36,6 +36,7 @@
     owner: "{{ owner }}"
     group: "{{ group }}"
     mode: 0777
+  ignore_errors: true
   tags:
     - install
     - update

--- a/roles/kubernetes/node/labels_taints/roles/tasks/main.yaml
+++ b/roles/kubernetes/node/labels_taints/roles/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Label/Taints for cluster nodes
   ansible.builtin.shell: |
-    kubectl label nodes {{ ansible_nodename }} node-role.kubernetes.io/node= --overwrite
+    kubectl label nodes {{ ansible_hostname }} node-role.kubernetes.io/node= --overwrite
   delegate_to: "{{groups['k8s_control_plane'][0]}}"
   tags:
     - install

--- a/roles/kubernetes/node/labels_taints/system/tasks/main.yaml
+++ b/roles/kubernetes/node/labels_taints/system/tasks/main.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Label/Taints for System/Default node
   ansible.builtin.shell: |
-    kubectl label nodes {{ ansible_nodename }} kubernetes.azure.com/mode=system --overwrite
-    kubectl label nodes {{ ansible_nodename }} node-role.kubernetes.io/system-node= --overwrite
+    kubectl label nodes {{ ansible_hostname }} kubernetes.azure.com/mode=system --overwrite
+    kubectl label nodes {{ ansible_hostname }} node-role.kubernetes.io/system-node= --overwrite
   delegate_to: "{{groups['k8s_control_plane'][0]}}"
   tags:
     - install

--- a/roles/kubernetes/node/labels_taints/tasks/labels.yaml
+++ b/roles/kubernetes/node/labels_taints/tasks/labels.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Applying labels
   ansible.builtin.shell: |
-    kubectl label nodes {{ ansible_nodename }} {{ label }} --overwrite 
+    kubectl label nodes {{ ansible_hostname }} {{ label }} --overwrite 
   with_items: "{{ labels }}"
   loop_control:
     loop_var: label

--- a/roles/kubernetes/node/labels_taints/tasks/taints.yaml
+++ b/roles/kubernetes/node/labels_taints/tasks/taints.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Applying taints
   ansible.builtin.shell: |
-    kubectl taint nodes {{ ansible_nodename }} {{ taint }} --overwrite 
+    kubectl taint nodes {{ ansible_hostname }} {{ taint }} --overwrite 
   with_items: "{{ taints }}"
   loop_control:
     loop_var: taint

--- a/roles/kubernetes/node/removal/tasks/main.yaml
+++ b/roles/kubernetes/node/removal/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Draining the node
   ansible.builtin.shell: |
-    kubectl drain {{ ansible_nodename }} --delete-emptydir-data --force --ignore-daemonsets
+    kubectl drain {{ ansible_hostname }} --delete-emptydir-data --force --ignore-daemonsets
   delegate_to: "{{groups['k8s_control_plane'][0]}}"
   ignore_errors: true
   tags:
@@ -22,7 +22,7 @@
 
 - name: Remove the node
   ansible.builtin.shell: |
-    kubectl delete nodes {{ ansible_nodename }}
+    kubectl delete nodes {{ ansible_hostname }}
   delegate_to: "{{groups['k8s_control_plane'][0]}}"
   ignore_errors: true
   tags:

--- a/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
+++ b/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
@@ -11,7 +11,7 @@ LOCAL_VOLUME_CONFIG:
     serviceAccount:
       create: true
   classes:
-    - name: local-storage # Defines name of storage class.
+    - name: local-storage
       hostDir: /mnt/sas/volumes
       volumeMode: Filesystem
       fsType: xfs

--- a/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
+++ b/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
@@ -1,0 +1,60 @@
+## sig-storage-local-static-provisioner
+LOCAL_VOLUME_NAME: sig-storage-local-static-provisioner-sas
+LOCAL_VOLUME_NAMESPACE: kube-system
+LOCAL_VOLUME_CHART_NAME: Chart.yaml
+LOCAL_VOLUME_REPO: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner.git
+LOCAL_VOLUME_CHART_VERSION: 2.4.0
+LOCAL_VOLUME_REPO_VERSION: "v{{ LOCAL_VOLUME_CHART_VERSION }}"
+LOCAL_VOLUME_REPO_LOCATION: "/tmp/{{ LOCAL_VOLUME_NAME }}"
+LOCAL_VOLUME_CONFIG:
+  classes:
+    - name: local-storage # Defines name of storage class.
+      hostDir: /mnt/sas/volumes
+      volumeMode: Filesystem
+      fsType: ext4
+      namePattern: "*"
+      blockCleanerCommand:
+        - "/scripts/shred.sh"
+        - "2"
+      storageClass: true
+
+  daemonset:
+    tolerations:
+    - effect: NoSchedule
+      key: workload.sas.com/class
+      operator: Equal
+      value: stateful
+    - effect: NoSchedule
+      key: workload.sas.com/class
+      operator: Equal
+      value: stateless
+
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+            - key: workload.sas.com/class
+              operator: In
+              values:
+              - stateful
+            matchFields: []
+          weight: 100
+        - preference:
+            matchExpressions:
+            - key: workload.sas.com/class
+              operator: NotIn
+              values:
+              - compute
+              - cas
+              - stateless
+            matchFields: []
+          weight: 50
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.azure.com/mode
+              operator: NotIn
+              values:
+              - system
+            matchFields: []

--- a/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
+++ b/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
@@ -7,17 +7,19 @@ LOCAL_VOLUME_CHART_VERSION: 2.4.0
 LOCAL_VOLUME_REPO_VERSION: "v{{ LOCAL_VOLUME_CHART_VERSION }}"
 LOCAL_VOLUME_REPO_LOCATION: "/tmp/{{ LOCAL_VOLUME_NAME }}"
 LOCAL_VOLUME_CONFIG:
+  common:
+    serviceAccount:
+      create: true
   classes:
     - name: local-storage # Defines name of storage class.
       hostDir: /mnt/sas/volumes
       volumeMode: Filesystem
-      fsType: ext4
+      fsType: xfs
       namePattern: "*"
       blockCleanerCommand:
         - "/scripts/shred.sh"
         - "2"
       storageClass: true
-
   daemonset:
     tolerations:
     - effect: NoSchedule
@@ -28,7 +30,6 @@ LOCAL_VOLUME_CONFIG:
       key: workload.sas.com/class
       operator: Equal
       value: stateless
-
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:

--- a/roles/kubernetes/storage/sig-storage-local-static-provisioner/tasks/main.yaml
+++ b/roles/kubernetes/storage/sig-storage-local-static-provisioner/tasks/main.yaml
@@ -1,0 +1,40 @@
+---
+# NOTE: The usage and setting of the iac_inventory_dir variable
+#       is only needed given this task is run on localhost
+#       an implied localhost and this keeps the magic inventory_file
+#       and inventory_dir from having values.
+#
+#       Reference URL : https://docs.ansible.com/ansible/latest/inventory/implicit_localhost.html
+#
+- name: Cloning sig-storage-local-static-provisioner
+  ansible.builtin.git:
+    repo: "{{ LOCAL_VOLUME_REPO }}"
+    dest: "/tmp/{{ LOCAL_VOLUME_NAME }}"
+    version: "{{ LOCAL_VOLUME_REPO_VERSION }}"
+  tags:
+    - install
+    - update
+
+- name: Setting up default storage for cluster using sig-storage-local-static-provisioner 
+  kubernetes.core.helm:
+    name: "{{ LOCAL_VOLUME_NAME }}"
+    namespace: "{{ LOCAL_VOLUME_NAMESPACE }}"
+    chart_ref: "{{ LOCAL_VOLUME_REPO_LOCATION }}/helm/provisioner"
+    chart_version: "{{ LOCAL_VOLUME_CHART_VERSION }}"
+    values: "{{ LOCAL_VOLUME_CONFIG }}"
+    kubeconfig: "{{ iac_inventory_dir }}/{{ kubernetes_cluster_name }}-kubeconfig.conf"
+    create_namespace: true
+    wait: true
+  tags:
+    - install
+    - update
+
+- name: Remove sig-storage-local-static-provisioner
+  kubernetes.core.helm:
+    name: "{{ LOCAL_VOLUME_NAME }}"
+    namespace: "{{ LOCAL_VOLUME_NAMESPACE }}"
+    kubeconfig: "{{ iac_inventory_dir }}/{{ kubernetes_cluster_name }}-kubeconfig.conf"
+    wait: true
+    state: absent
+  tags:
+    - uninstall

--- a/roles/systems/vsphere/init/files/create_partitions.sh
+++ b/roles/systems/vsphere/init/files/create_partitions.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+all_disks=($(/usr/bin/lsblk --nodeps --noheadings --output NAME --paths | grep sd))
+for disk in "${all_disks[@]}"; do
+  partitions="$(/usr/bin/lsblk --noheadings --output PTTYPE "${disk}" | grep -vE "^$")"
+  if [ "${partitions}" == "" ]; then
+    fdisk ${disk} << EOF
+n
+p
+1
+
+
+w
+EOF
+  fi
+done

--- a/roles/systems/vsphere/init/files/link_devs.sh
+++ b/roles/systems/vsphere/init/files/link_devs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Find all disks not currently partitioned and add a partition for
+all_disks=($(/usr/bin/lsblk --nodeps --noheadings --output NAME --paths | grep sd))
+for disk in "${all_disks[@]}"; do
+  partitions="$(/usr/bin/lsblk --noheadings --output PTTYPE "${disk}" | grep -vE "^$")"
+  if [ "${partitions}" == "" ]; then
+    # Capture the SERIAL number of the disk being used
+    SERIAL_NUMBER=$(lsblk --noheadings --output SERIAL "${disk}" | grep -vE "^$" )
+    if [[ "${disk}" =~ .*\/(.*)$ ]]; then
+      RDISK="${BASH_REMATCH[1]}"
+      if [ "${SERIAL_NUMBER}" != "" ]; then
+        # Verifying the /mnt/sas/volumes directory is present
+        if [[ ! -d /mnt/sas/volumes/ ]]; then
+          mkdir -p /mnt/sas/volumes
+        fi
+        if [[ ! -L "/mnt/sas/volumes/sas-v4-${RDISK}-${SERIAL_NUMBER}" ]]; then
+          ln -s "${disk}" "/mnt/sas/volumes/sas-v4-${RDISK}-${SERIAL_NUMBER}"
+        fi
+      fi
+    fi
+  fi
+done

--- a/roles/systems/vsphere/init/tasks/main.yaml
+++ b/roles/systems/vsphere/init/tasks/main.yaml
@@ -29,18 +29,49 @@
   tags:
     - install
 
-- name: Copy partitioning script
+- name: Set owner and group for Ubuntu OS
+  ansible.builtin.set_fact:
+    owner: nobody
+    group: nogroup
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version == "20.04"
+  tags:
+    - install
+    - update
+
+- name: Create /mnt/sas/volumes directory
+  ansible.builtin.file:
+    path: /mnt/sas/volumes
+    state: directory
+    owner: "{{ owner }}"
+    group: "{{ group }}"
+    mode: 0777
+  ignore_errors: true
+  tags:
+    - install
+    - update
+
+#
+# Create local-static-provisioner items for later use
+#
+
+# Copy script
+- name: Copy link creation script
   ansible.builtin.copy:
-    src: ./files/create_partitions.sh
-    dest: /tmp/create_partitions.sh
+    src: ./files/link_devs.sh
+    dest: /tmp/link_devs.sh
     owner: root
     group: root
     mode: '0700'
   tags:
     - install
 
-- name: Run partitioning script
+# TODO: Add code here to add partitions for disks
+#       that are not going to be used for local-static
+#       storage class storage
+
+# Run script
+- name: Run link creation script
   ansible.builtin.shell: |
-    /tmp/create_partitions.sh
+    /tmp/link_devs.sh
   tags:
     - install

--- a/roles/systems/vsphere/init/tasks/main.yaml
+++ b/roles/systems/vsphere/init/tasks/main.yaml
@@ -28,3 +28,19 @@
   ansible.builtin.shell: "xfs_growfs -d /"
   tags:
     - install
+
+- name: Copy partitioning script
+  ansible.builtin.copy:
+    src: ./files/create_partitions.sh
+    dest: /tmp/create_partitions.sh
+    owner: root
+    group: root
+    mode: '0700'
+  tags:
+    - install
+
+- name: Run partitioning script
+  ansible.builtin.shell: |
+    /tmp/create_partitions.sh
+  tags:
+    - install

--- a/templates/ansible/ansible-vars.yaml.tmpl
+++ b/templates/ansible/ansible-vars.yaml.tmpl
@@ -104,3 +104,8 @@ jump_ip : "${jump_ip}"
 # NFS Server
 nfs_ip  : "${nfs_ip}"
 %{ endif ~}
+
+%{ if length(cr_ip) != 0 ~}
+# Container Registry
+cr_ip   : "${cr_ip}"
+%{ endif ~}

--- a/templates/ansible/inventory.tmpl
+++ b/templates/ansible/inventory.tmpl
@@ -65,6 +65,20 @@ ${nfs_ip}
 nfs_server
 %{ endif ~}
 
+%{ if length(cr_ip) != 0 ~}
+#
+# Container Registry
+#
+[cr_server]
+${cr_ip}
+
+#
+# Container Registry - alias - DO NOT MODIFY
+#
+[cr:children]
+cr_server
+%{ endif ~}
+
 %{ if length(postgres_servers) != 0 ~}
 #
 # Postgres Servers
@@ -94,7 +108,12 @@ k8s
 %{ if length(jump_ip) != 0 ~}
 jump
 %{ endif ~}
+%{ if length(nfs_ip) != 0 ~}
 nfs
+%{ endif ~}
+%{ if length(cr_ip) != 0 ~}
+cr
+%{ endif ~}
 %{ if length(postgres_servers) != 0 ~}
 postgres
 %{ endif ~}

--- a/templates/ansible/inventory.tmpl
+++ b/templates/ansible/inventory.tmpl
@@ -89,8 +89,8 @@ ${server_data.server_ip}
 [${prefix}_${server_name}_pgsql:vars]
 postgres_server_name=${server_name}
 postgres_server_version=${server_data.server_version}
-postgres_server_ssl=${server_data.server_ssl}  # NOTE: Values - [on,off]
-postgres_administrator_login=${server_data.administrator_login} # NOTE: Do not change this value at this time
+postgres_server_ssl=${server_data.server_ssl}
+postgres_administrator_login=${server_data.administrator_login}
 postgres_administrator_password=${server_data.administrator_password}
 
 %{ endfor ~}

--- a/variables.tf
+++ b/variables.tf
@@ -122,7 +122,8 @@ variable "node_pool_defaults" {
   default = {
     cpus         = 2
     memory       = 4096
-    disk         = 25
+    os_disk      = 25
+    misc_disks   = []
     count        = 0
     ip_addresses = []
     node_taints  = []
@@ -213,6 +214,31 @@ variable "nfs_disk_size" {
   default = 250
 }
 
+# container registry
+variable "create_cr" {
+  type    = bool
+  default = false
+}
+variable "cr_ip" {
+  type    = string
+  default = null
+}
+
+variable "cr_memory" {
+  type    = number
+  default = 8092
+}
+
+variable "cr_num_cpu" {
+  type    = number
+  default = 4
+}
+
+variable "cr_disk_size" {
+  type    = number
+  default = 160
+}
+
 # postgres
 variable "postgres_server_defaults" {
   description = ""
@@ -260,7 +286,7 @@ variable "system_ssh_keys_dir" {
 }
 
 variable "cluster_domain" {
-  type = string
+  type    = string
   default = null
 }
 


### PR DESCRIPTION
Add in code to add n number of misc disks to a vm when identified in the node_pools configuration. Also added in the skeleton for the container registry VM. 