### PR TITLE
(IAC-605) Don't replace GRUB_CMDLINE_LINUX if it already exists

### DIFF
--- a/roles/kubernetes/common/tasks/main.yaml
+++ b/roles/kubernetes/common/tasks/main.yaml
@@ -42,37 +42,33 @@
       register: grub_content
       changed_when: False
 
-    - name: Adding GRUB_CMDLINE_LINUX to /etc/default/grub if absent
+    - name: Retrieve existing GRUB_CMDLINE_LINUX options, if any
+      set_fact:
+        grub_cmdline_original: "{{ grub_content.stdout | regex_search('^GRUB_CMDLINE_LINUX=\"([^\"]*)\"$', '\\1', multiline=True) }}"
+
+    - name: Set {{ option }}={{ value }} if option previously disabled
+      set_fact:
+        grub_cmdline_updated: "{{ grub_cmdline_original.0 | default('') | replace(option + '=0', option + '=' + value) }}"
+
+    - name: Adding {{ option }}={{ value }} if option not present
+      set_fact:
+        grub_cmdline_updated: '{{ (grub_cmdline_updated + " " + option + "=" + value) | trim }}'
+      when: 'option not in grub_cmdline_updated'
+
+    - name: Adding updated GRUB_CMDLINE_LINUX to /etc/default/grub file
       ansible.builtin.lineinfile:
         path: /etc/default/grub
-        line: 'GRUB_CMDLINE_LINUX="{{ option }}={{ value }}"'
+        regexp: '^GRUB_CMDLINE_LINUX='
+        line: 'GRUB_CMDLINE_LINUX="{{ grub_cmdline_updated }}"'
         owner: root
         group: root
         mode: '0644'
-      when: '"GRUB_CMDLINE_LINUX=" not in grub_content.stdout'
-
-    - name: Adding {{ option }}=={{ value }} to existing GRUB_CMDLINE_LINUX in /etc/default/grub
-      ansible.builtin.lineinfile:
-        path: /etc/default/grub
-        backrefs: yes
-        regexp: '^(GRUB_CMDLINE_LINUX=(?!.*{{ option | regex_escape }})"[^"]*)(")'
-        line: '\1 {{ option }}={{ value }}\2'
-        owner: root
-        group: root
-        mode: '0644'
-      when: '"GRUB_CMDLINE_LINUX=" in grub_content.stdout'
-
-    - name: Ensure {{ option }}=={{ value }} if previously disabled
-      ansible.builtin.replace:
-        path: /etc/default/grub
-        regexp: '{{ option | regex_escape }}=0'
-        replace: '{{ option }}={{ value }}'
 
     - name: Update GRUB
       ansible.builtin.command: update-grub
   vars:
     option: systemd.unified_cgroup_hierarchy
-    value: 1
+    value: "1"
   tags:
     - install
 

--- a/roles/kubernetes/common/tasks/main.yaml
+++ b/roles/kubernetes/common/tasks/main.yaml
@@ -37,16 +37,42 @@
 
 - name: Enable cgroup v2 # https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cgroup-v2
   block:
-    - name: Adding GRUB_CMDLINE_LINUX to /etc/default/grub file
+    - name: Retrieve contents of /etc/default/grub
+      ansible.builtin.shell: cat /etc/default/grub
+      register: grub_content
+      changed_when: False
+
+    - name: Adding GRUB_CMDLINE_LINUX to /etc/default/grub if absent
       ansible.builtin.lineinfile:
         path: /etc/default/grub
-        regexp: '^GRUB_CMDLINE_LINUX='
-        line: GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=1"
+        line: 'GRUB_CMDLINE_LINUX="{{ option }}={{ value }}"'
         owner: root
         group: root
         mode: '0644'
+      when: '"GRUB_CMDLINE_LINUX=" not in grub_content.stdout'
+
+    - name: Adding {{ option }}=={{ value }} to existing GRUB_CMDLINE_LINUX in /etc/default/grub
+      ansible.builtin.lineinfile:
+        path: /etc/default/grub
+        backrefs: yes
+        regexp: '^(GRUB_CMDLINE_LINUX=(?!.*{{ option | regex_escape }})"[^"]*)(")'
+        line: '\1 {{ option }}={{ value }}\2'
+        owner: root
+        group: root
+        mode: '0644'
+      when: '"GRUB_CMDLINE_LINUX=" in grub_content.stdout'
+
+    - name: Ensure {{ option }}=={{ value }} if previously disabled
+      ansible.builtin.replace:
+        path: /etc/default/grub
+        regexp: '{{ option | regex_escape }}=0'
+        replace: '{{ option }}={{ value }}'
+
     - name: Update GRUB
       ansible.builtin.command: update-grub
+  vars:
+    option: systemd.unified_cgroup_hierarchy
+    value: 1
   tags:
     - install
 


### PR DESCRIPTION
Currently the project simply replaces the entire GRUB_CMDLINE_LINUX line, regardless of whether the user already has options set here. It should instead only add the needed option to the existing line.

I imagine this could all be done with a single regex if one wanted to take the time to devise one, but the solutions I found online were impossible to understand and didn't work as advertised. The added code can be understood relatively easily and should cover most cases. Tested with:

1. GRUB_CMDLINE_LINUX not in file at all. Added as: 

`GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=1"`

2. GRUB_CMDLINE_LINUX in file but an empty string. Updated to:

`GRUB_CMDLINE_LINUX=" systemd.unified_cgroup_hierarchy=1"`

3. Option present but contains unrelated setting "foo". Updated to: 

`GRUB_CMDLINE_LINUX="foo systemd.unified_cgroup_hierarchy=1"`

4. GRUB_CMDLINE_LINUX present and option systemd.unified_cgroup_hierarchy disabled. Updated to: 

`GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=1"`

5. GRUB_CMDLINE_LINUX present and option systemd.unified_cgroup_hierarchy already enabled. No change: 

`GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=1"`

