### PR TITLE
fix: (IAC-621) Update Ansible template files

### DIFF
--- a/templates/ansible/ansible-vars.yaml.tmpl
+++ b/templates/ansible/ansible-vars.yaml.tmpl
@@ -94,14 +94,18 @@ node_taints:
 %{ endfor ~}
 %{ endif ~}
 
+%{ if length(jump_ip) != null ~}
 %{ if length(jump_ip) != 0 ~}
 # Jump Server
 jump_ip : "${jump_ip}"
 %{ endif ~}
+%{ endif ~}
 
+%{ if length(nfs_ip) != null ~}
 %{ if length(nfs_ip) != 0 ~}
 # NFS Server
 nfs_ip  : "${nfs_ip}"
+%{ endif ~}
 %{ endif ~}
 
 %{ if cr_ip != null ~}

--- a/templates/ansible/ansible-vars.yaml.tmpl
+++ b/templates/ansible/ansible-vars.yaml.tmpl
@@ -94,14 +94,14 @@ node_taints:
 %{ endfor ~}
 %{ endif ~}
 
-%{ if length(jump_ip) != null ~}
+%{ if jump_ip != null ~}
 %{ if length(jump_ip) != 0 ~}
 # Jump Server
 jump_ip : "${jump_ip}"
 %{ endif ~}
 %{ endif ~}
 
-%{ if length(nfs_ip) != null ~}
+%{ if nfs_ip != null ~}
 %{ if length(nfs_ip) != 0 ~}
 # NFS Server
 nfs_ip  : "${nfs_ip}"

--- a/templates/ansible/ansible-vars.yaml.tmpl
+++ b/templates/ansible/ansible-vars.yaml.tmpl
@@ -104,7 +104,9 @@ jump_ip : "${jump_ip}"
 nfs_ip  : "${nfs_ip}"
 %{ endif ~}
 
+%{ if cr_ip != null ~}
 %{ if length(cr_ip) != 0 ~}
 # Container Registry
 cr_ip   : "${cr_ip}"
+%{ endif ~}
 %{ endif ~}

--- a/templates/ansible/inventory.tmpl
+++ b/templates/ansible/inventory.tmpl
@@ -65,6 +65,7 @@ ${nfs_ip}
 nfs_server
 %{ endif ~}
 
+%{ if cr_ip != null ~}
 %{ if length(cr_ip) != 0 ~}
 #
 # Container Registry
@@ -77,6 +78,7 @@ ${cr_ip}
 #
 [cr:children]
 cr_server
+%{ endif ~}
 %{ endif ~}
 
 %{ if length(postgres_servers) != 0 ~}
@@ -111,8 +113,10 @@ jump
 %{ if length(nfs_ip) != 0 ~}
 nfs
 %{ endif ~}
+%{ if cr_ip != null ~}
 %{ if length(cr_ip) != 0 ~}
 cr
+%{ endif ~}
 %{ endif ~}
 %{ if length(postgres_servers) != 0 ~}
 postgres

--- a/templates/ansible/inventory.tmpl
+++ b/templates/ansible/inventory.tmpl
@@ -37,7 +37,7 @@ FIXME - ENTER YOUR KUBERNETES COMPUTE NODE IPs/FQDNs HERE!
 k8s_control_plane
 k8s_node
 
-%{ if length(jump_ip) != null ~}
+%{ if jump_ip != null ~}
 %{ if length(jump_ip) != 0 ~}
 #
 # Jump Server
@@ -53,7 +53,7 @@ jump_server
 %{ endif ~}
 %{ endif ~}
 
-%{ if length(nfs_ip) != null ~}
+%{ if nfs_ip != null ~}
 %{ if length(nfs_ip) != 0 ~}
 #
 # NFS Server
@@ -111,12 +111,12 @@ ${prefix}_${server_name}_pgsql
 #
 [all:children]
 k8s
-%{ if length(jump_ip) != null ~}
+%{ if jump_ip != null ~}
 %{ if length(jump_ip) != 0 ~}
 jump
 %{ endif ~}
 %{ endif ~}
-%{ if length(nfs_ip) != null ~}
+%{ if nfs_ip != null ~}
 %{ if length(nfs_ip) != 0 ~}
 nfs
 %{ endif ~}

--- a/templates/ansible/inventory.tmpl
+++ b/templates/ansible/inventory.tmpl
@@ -37,6 +37,7 @@ FIXME - ENTER YOUR KUBERNETES COMPUTE NODE IPs/FQDNs HERE!
 k8s_control_plane
 k8s_node
 
+%{ if length(jump_ip) != null ~}
 %{ if length(jump_ip) != 0 ~}
 #
 # Jump Server
@@ -50,7 +51,9 @@ ${jump_ip}
 [jump:children]
 jump_server
 %{ endif ~}
+%{ endif ~}
 
+%{ if length(nfs_ip) != null ~}
 %{ if length(nfs_ip) != 0 ~}
 #
 # NFS Server
@@ -63,6 +66,7 @@ ${nfs_ip}
 #
 [nfs:children]
 nfs_server
+%{ endif ~}
 %{ endif ~}
 
 %{ if cr_ip != null ~}
@@ -107,11 +111,15 @@ ${prefix}_${server_name}_pgsql
 #
 [all:children]
 k8s
+%{ if length(jump_ip) != null ~}
 %{ if length(jump_ip) != 0 ~}
 jump
 %{ endif ~}
+%{ endif ~}
+%{ if length(nfs_ip) != null ~}
 %{ if length(nfs_ip) != 0 ~}
 nfs
+%{ endif ~}
 %{ endif ~}
 %{ if cr_ip != null ~}
 %{ if length(cr_ip) != 0 ~}


### PR DESCRIPTION
## Changes
Fixes logic in the ansible template files for the cr, jump, and nfs vms, so if the user opts to not create one of those resources it no longer throws an error.

## Tests

## Scenario 1:

Set the create flags for all the external servers to true, I also opted to use static ips for these resources 
```
create_jump = true
create_nfs = true
create_cr = true
```

Resources were successfully created, both the inventory and ansible-vars.yaml template successfully rendered and saved to disk WITH the jump, nfs, and cr sections


## Scenario 2:

Set the create flags for all the external servers to false
```
create_jump = false
create_nfs = false
create_cr = false
```

Resources were not created as expected, and both the inventory and ansible-vars.yaml template successfully rendered and saved to disk WITHOUT the jump, nfs, and cr sections



## Scenario 3:

Ensure that the create flags are not in the tfvars (create_jump, create_nfs, create_cr) so that they fallback on the their default value of false


Resources were not created as expected, and both the inventory and ansible-vars.yaml template successfully rendered and saved to disk WITHOUT the jump, nfs, and cr sections
