### PR TITLE
fix: (IAC-578) Update SSL Cert/Key Naming Scheme

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -261,7 +261,7 @@ nfs_ip        = ""    # Assigned values for static IP addresses
 
 **NOTES**:
 
-1. If you set `server_ssl` to on, and you do not define either `server_ssl_cert_file` or `server_ssl_cert_file` the system's default SSL certificate and key will be used instead. By default, on Ubuntu systems we create a copy of those files and name them `ssl-cert-sas_${PG_HOST}.pem` and `ssl-cert-sas_${PG_HOST}.key`
+1. If you set `server_ssl` to on, and you do not define either `server_ssl_cert_file` or `server_ssl_cert_file` the system's default SSL certificate and key will be used instead. By default, on Ubuntu systems we create a copy of those files and name them `ssl-cert-sas-${PG_HOST}.pem` and `ssl-cert-sas-${PG_HOST}.key`
     * The Ansible tasks will take care of copying the certificate and key from the Postgres VM into your local workspace directory
 2. If you are planning on using the [viya4-deployment repository](https://github.com/sassoftware/viya4-deployment) to perform a Viya deployment where you have [full-stack TLS](https://github.com/sassoftware/viya4-deployment/blob/main/docs/CONFIG-VARS.md#tls), ensure in the viya4-deployment ansible-vars.yaml the `V4_CFG_TLS_TRUSTED_CA_CERTS` variable points to a directory that contains the `server_ssl_cert_file`.
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -261,7 +261,7 @@ nfs_ip        = ""    # Assigned values for static IP addresses
 
 **NOTES**:
 
-1. If you set `server_ssl` to on, and you do not define either `server_ssl_cert_file` or `server_ssl_cert_file` the system's default SSL certificate and key will be used instead. By default, on Ubuntu systems we create a copy of those files and name them `ssl-cert-sas.pem` and `ssl-cert-sas.key`
+1. If you set `server_ssl` to on, and you do not define either `server_ssl_cert_file` or `server_ssl_cert_file` the system's default SSL certificate and key will be used instead. By default, on Ubuntu systems we create a copy of those files and name them `ssl-cert-sas_${PG_HOST}.pem` and `ssl-cert-sas_${PG_HOST}.key`
     * The Ansible tasks will take care of copying the certificate and key from the Postgres VM into your local workspace directory
 2. If you are planning on using the [viya4-deployment repository](https://github.com/sassoftware/viya4-deployment) to perform a Viya deployment where you have [full-stack TLS](https://github.com/sassoftware/viya4-deployment/blob/main/docs/CONFIG-VARS.md#tls), ensure in the viya4-deployment ansible-vars.yaml the `V4_CFG_TLS_TRUSTED_CA_CERTS` variable points to a directory that contains the `server_ssl_cert_file`.
 

--- a/roles/systems/postgres/tasks/main.yaml
+++ b/roles/systems/postgres/tasks/main.yaml
@@ -101,7 +101,7 @@
     - name: Copy Ubuntu default SSL Cert
       ansible.builtin.copy:
         src: /etc/ssl/certs/ssl-cert-snakeoil.pem
-        dest: "/etc/ssl/certs/ssl-cert-sas-{{ inventory_hostname }}.pem"
+        dest: "/etc/ssl/certs/ssl-cert-sas-{{ ansible_hostname }}.pem"
         owner: root
         group: root
         mode: "0644"
@@ -110,7 +110,7 @@
     - name: Copy Ubuntu default SSL Key
       ansible.builtin.copy:
         src: /etc/ssl/private/ssl-cert-snakeoil.key
-        dest: "/etc/ssl/private/ssl-cert-sas-{{ inventory_hostname }}.key"
+        dest: "/etc/ssl/private/ssl-cert-sas-{{ ansible_hostname }}.key"
         owner: root
         group: ssl-cert
         mode: "0640"

--- a/roles/systems/postgres/tasks/main.yaml
+++ b/roles/systems/postgres/tasks/main.yaml
@@ -101,7 +101,7 @@
     - name: Copy Ubuntu default SSL Cert
       ansible.builtin.copy:
         src: /etc/ssl/certs/ssl-cert-snakeoil.pem
-        dest: /etc/ssl/certs/ssl-cert-sas.pem
+        dest: "/etc/ssl/certs/ssl-cert-sas_{{ inventory_hostname }}.pem"
         owner: root
         group: root
         mode: "0644"
@@ -110,7 +110,7 @@
     - name: Copy Ubuntu default SSL Key
       ansible.builtin.copy:
         src: /etc/ssl/private/ssl-cert-snakeoil.key
-        dest: /etc/ssl/private/ssl-cert-sas.key
+        dest: "/etc/ssl/private/ssl-cert-sas_{{ inventory_hostname }}.key"
         owner: root
         group: ssl-cert
         mode: "0640"

--- a/roles/systems/postgres/tasks/main.yaml
+++ b/roles/systems/postgres/tasks/main.yaml
@@ -101,7 +101,7 @@
     - name: Copy Ubuntu default SSL Cert
       ansible.builtin.copy:
         src: /etc/ssl/certs/ssl-cert-snakeoil.pem
-        dest: "/etc/ssl/certs/ssl-cert-sas_{{ inventory_hostname }}.pem"
+        dest: "/etc/ssl/certs/ssl-cert-sas-{{ inventory_hostname }}.pem"
         owner: root
         group: root
         mode: "0644"
@@ -110,7 +110,7 @@
     - name: Copy Ubuntu default SSL Key
       ansible.builtin.copy:
         src: /etc/ssl/private/ssl-cert-snakeoil.key
-        dest: "/etc/ssl/private/ssl-cert-sas_{{ inventory_hostname }}.key"
+        dest: "/etc/ssl/private/ssl-cert-sas-{{ inventory_hostname }}.key"
         owner: root
         group: ssl-cert
         mode: "0640"


### PR DESCRIPTION
## Changes 
Updating the SSL cert/key naming scheme that is used if you set `server_ssl` to on, and you do not define either `server_ssl_cert_file` or `server_ssl_cert_file`. The files will now have the format `ssl-cert-sas-${PG_HOST}.pem` and `ssl-cert-sas-${PG_HOST}.key`. The cert/key file should no longer be overwritten when mutliple postgres hosts are created using this configuration.

## Tests

Additional details in internal ticket, test summary:

1. Created a .tfvars that included 2 postgres servers (named default & extra) both with `server_ssl` on and `server_ssl_cert_file` or `server_ssl_cert_file` not set
2. Ran "apply setup install"
3. Infrastructure was successfully created
4. Both PG VMs had postgres installed and correctly configured with ssl on and both the cert & key set
5. On the PG VMs the cert & key files were correctly named
6. Ansible was able to succesfully fetch both the cert & key files on both PG VMs onto the bastion host.
7. On the bastion host the cert & key files were correctly named
8. Performed a full-stack Viya deployment and pods were able to communicate with the default PG instance
9. Was able to go into SASEnvironmentManager and connect with my extra PG instance.