### PR TITLE
docs: (IAC-671) Update kube-vip URL

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -420,8 +420,8 @@ kubernetes_pod_subnet      : ""
 # 
 # Useful links:
 #
-#   VIP IP :  https://kube-vip.io/docs/installation/static/
-#   VIP Cloud Provider IP Range :  https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
+#   VIP IP : https://kube-vip.io/docs/installation/static/
+#   VIP Cloud Provider IP Range : https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
 #
 kubernetes_vip_version              : "0.4.4"
 kubernetes_vip_interface            : ""

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -420,8 +420,8 @@ kubernetes_pod_subnet      : ""
 # 
 # Useful links:
 #
-#   VIP IP : https://kube-vip.chipzoller.dev/docs/installation/static/
-#   VIP Cloud Provider IP Range : https://kube-vip.chipzoller.dev/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
+#   VIP IP :  https://kube-vip.io/docs/installation/static/
+#   VIP Cloud Provider IP Range :  https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
 #
 kubernetes_vip_version              : "0.4.4"
 kubernetes_vip_interface            : ""

--- a/examples/bare-metal/sample-ansible-vars.yaml
+++ b/examples/bare-metal/sample-ansible-vars.yaml
@@ -32,8 +32,8 @@ kubernetes_pod_subnet      : ""
 # 
 # Useful links:
 #
-#   VIP IP : https://kube-vip.chipzoller.dev/docs/installation/static/
-#   VIP Cloud Provider IP Range : https://kube-vip.chipzoller.dev/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
+#   VIP IP :  https://kube-vip.io/docs/installation/static/
+#   VIP Cloud Provider IP Range :  https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
 #
 kubernetes_vip_version              : "0.4.4"
 kubernetes_vip_interface            : ""

--- a/examples/bare-metal/sample-ansible-vars.yaml
+++ b/examples/bare-metal/sample-ansible-vars.yaml
@@ -32,8 +32,8 @@ kubernetes_pod_subnet      : ""
 # 
 # Useful links:
 #
-#   VIP IP :  https://kube-vip.io/docs/installation/static/
-#   VIP Cloud Provider IP Range :  https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
+#   VIP IP : https://kube-vip.io/docs/installation/static/
+#   VIP Cloud Provider IP Range : https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
 #
 kubernetes_vip_version              : "0.4.4"
 kubernetes_vip_interface            : ""

--- a/playbooks/kubernetes-install.yaml
+++ b/playbooks/kubernetes-install.yaml
@@ -24,7 +24,7 @@
   become: true
   become_user: root
   roles:
-    - { role: kubernetes/loadbalancer/kube_vip/primary } # kube-vip :  https://kube-vip.io/docs/installation/static/
+    - { role: kubernetes/loadbalancer/kube_vip/primary } # kube-vip : https://kube-vip.io/docs/installation/static/
     - { role: kubernetes/control_plane/init/primary }
     - { role: "kubernetes/cni/{{ kubernetes_cni }}" }     # calico : https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises#install-calico-with-kubernetes-api-datastore-50-nodes-or-less
 

--- a/playbooks/kubernetes-install.yaml
+++ b/playbooks/kubernetes-install.yaml
@@ -24,7 +24,7 @@
   become: true
   become_user: root
   roles:
-    - { role: kubernetes/loadbalancer/kube_vip/primary } # kube-vip : https://kube-vip.chipzoller.dev/docs/installation/static/
+    - { role: kubernetes/loadbalancer/kube_vip/primary } # kube-vip :  https://kube-vip.io/docs/installation/static/
     - { role: kubernetes/control_plane/init/primary }
     - { role: "kubernetes/cni/{{ kubernetes_cni }}" }     # calico : https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises#install-calico-with-kubernetes-api-datastore-50-nodes-or-less
 

--- a/roles/kubernetes/loadbalancer/kube_vip/cloud_provider/templates/kube-vip-cm.tmpl
+++ b/roles/kubernetes/loadbalancer/kube_vip/cloud_provider/templates/kube-vip-cm.tmpl
@@ -1,4 +1,4 @@
-# Reference Link:  https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
+# Reference Link: https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/roles/kubernetes/loadbalancer/kube_vip/cloud_provider/templates/kube-vip-cm.tmpl
+++ b/roles/kubernetes/loadbalancer/kube_vip/cloud_provider/templates/kube-vip-cm.tmpl
@@ -1,4 +1,4 @@
-# Reference Link: https://kube-vip.chipzoller.dev/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
+# Reference Link:  https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/templates/ansible/ansible-vars.yaml.tmpl
+++ b/templates/ansible/ansible-vars.yaml.tmpl
@@ -32,8 +32,8 @@ kubernetes_pod_subnet      : "${ cluster_pod_subnet }"
 # 
 # Useful links:
 #
-#   VIP IP :  https://kube-vip.io/docs/installation/static/
-#   VIP Cloud Provider IP Range :  https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
+#   VIP IP : https://kube-vip.io/docs/installation/static/
+#   VIP Cloud Provider IP Range : https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
 #
 kubernetes_vip_version              : "${ kube_vip_version }"
 kubernetes_vip_ip                   : "${ kube_vip_ip }"

--- a/templates/ansible/ansible-vars.yaml.tmpl
+++ b/templates/ansible/ansible-vars.yaml.tmpl
@@ -32,8 +32,8 @@ kubernetes_pod_subnet      : "${ cluster_pod_subnet }"
 # 
 # Useful links:
 #
-#   VIP IP : https://kube-vip.chipzoller.dev/docs/installation/static/
-#   VIP Cloud Provider IP Range : https://kube-vip.chipzoller.dev/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
+#   VIP IP :  https://kube-vip.io/docs/installation/static/
+#   VIP Cloud Provider IP Range :  https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap
 #
 kubernetes_vip_version              : "${ kube_vip_version }"
 kubernetes_vip_ip                   : "${ kube_vip_ip }"


### PR DESCRIPTION
## Changes
`https://kube-vip.chipzoller.dev` should now be `https://kube-vip.io`

## Tests

Verified the updated URLs lead to the correct page & section