### PR TITLE
docs: (IAC-656) Update Supported Kubernetes Versions Link

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -71,6 +71,7 @@ Terraform input variables can be set in the following ways:
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
 cluster_version        | Kubernetes version | string | "1.22.10" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/v_031/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6) |cluster_cni            | Kubernetes Container Network Interface (CNI) | string | "calico" | |
+cluster_cni            | Kubernetes Container Network Interface (CNI) | string | "calico" | |
 cluster_cri            | Kubernetes Container Runtime Interface (CRI) | string | "containerd" | |
 cluster_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |
 cluster_pod_subnet     | Kubernetes Pod subnet | string | "10.42.0.0/16" | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -70,7 +70,7 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-cluster_version        | Kubernetes version | string | "1.22.10" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/v_031/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6) |
+cluster_version        | Kubernetes version | string | "1.22.10" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6) |
 cluster_cni            | Kubernetes Container Network Interface (CNI) | string | "calico" | |
 cluster_cri            | Kubernetes Container Runtime Interface (CRI) | string | "containerd" | |
 cluster_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -70,8 +70,7 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-cluster_version        | Kubernetes version | string | "1.22.10" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/) |
-cluster_cni            | Kubernetes Container Network Interface (CNI) | string | "calico" | |
+cluster_version        | Kubernetes version | string | "1.22.10" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/v_031/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6) |cluster_cni            | Kubernetes Container Network Interface (CNI) | string | "calico" | |
 cluster_cri            | Kubernetes Container Runtime Interface (CRI) | string | "containerd" | |
 cluster_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |
 cluster_pod_subnet     | Kubernetes Pod subnet | string | "10.42.0.0/16" | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -70,7 +70,7 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-cluster_version        | Kubernetes version | string | "1.22.10" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/v_031/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6) |cluster_cni            | Kubernetes Container Network Interface (CNI) | string | "calico" | |
+cluster_version        | Kubernetes version | string | "1.22.10" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/v_031/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6) |
 cluster_cni            | Kubernetes Container Network Interface (CNI) | string | "calico" | |
 cluster_cri            | Kubernetes Container Runtime Interface (CRI) | string | "containerd" | |
 cluster_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |


### PR DESCRIPTION
## Changes
Updated the link in the `cluster_version` cell to point to the SAS Viya Kubernetes version requirements information. This will make it clear which versions are supported in the context of Viya 4.

## Tests
Verified the link is formatted correctly and leads to the correct page/section