### PR TITLE
feat: (IAC-678) Use 'kubectl create' rather than 'kubectl apply' when creating calico resources

### DIFF
--- a/roles/kubernetes/cni/calico/tasks/main.yaml
+++ b/roles/kubernetes/cni/calico/tasks/main.yaml
@@ -6,7 +6,7 @@
 #
 - name: Install Operator
   ansible.builtin.shell: |
-    kubectl apply -f https://projectcalico.docs.tigera.io/manifests/tigera-operator.yaml
+    kubectl create -f https://projectcalico.docs.tigera.io/manifests/tigera-operator.yaml
   tags:
     - install
     - update
@@ -23,7 +23,7 @@
 
 - name: Apply custom-resources
   ansible.builtin.shell: |
-    kubectl apply -f /tmp/custom-resources.yaml
+    kubectl create -f /tmp/custom-resources.yaml
   tags:
     - install
     - update


### PR DESCRIPTION
New cluster creations are failing while installing the calico operator. Error is:

`"stderr": "The CustomResourceDefinition \"installations.operator.tigera.io\" is invalid: metadata.annotations: Too long: must have at most 262144 bytes"`

I don't know why I've just started seeing this; perhaps the CRD size has grown. 

The [calico docs](https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises#install-calico-with-kubernetes-api-datastore-50-nodes-or-less) indicate that 'kubectl create' should be used instead of 'kubectl apply'. The former avoids the creation of the 'last-applied-configuration' annotation, which is likely the problem here. I confirmed in my own environment that using 'kubectl create' yields a successfully created cluster.