### PR TITLE
feat: (IAC-657) Update default K8s version to 1.23.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && apt upgrade -y \
 # Layers used for building/downloading/installing tools
 FROM baseline as tool_builder
 ARG HELM_VERSION=3.8.1
-ARG KUBECTL_VERSION=1.22.10
+ARG KUBECTL_VERSION=1.23.8
 ARG TERRAFORM_VERSION=1.2.0
 
 WORKDIR /build

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -70,7 +70,7 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-cluster_version        | Kubernetes version | string | "1.22.10" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6) |
+cluster_version        | Kubernetes version | string | "1.23.8" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6) |
 cluster_cni            | Kubernetes Container Network Interface (CNI) | string | "calico" | |
 cluster_cri            | Kubernetes Container Runtime Interface (CRI) | string | "containerd" | |
 cluster_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |
@@ -300,7 +300,7 @@ Variables used to describe your machines.
 | prefix | A prefix used in the names of all the resources created by this script | string | | |
 | deployment_type | | string | | |
 | kubernetes_cluster_name | Cluster name | string | "{{ prefix }}-oss" | This item is auto-filled **ONLY** change the prefix value above |
-| kubernetes_version | Kubernetes version | string | "1.22.10" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/) |
+| kubernetes_version | Kubernetes version | string | "1.23.8" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/) |
 | kubernetes_upgrade_allowed | | bool | true | |
 | kubernetes_arch | | string | "{{ vm_arch }}" | |
 | kubernetes_cni | Kubernetes Container Network Interface (CNI) | string | "calico" | |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -139,7 +139,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh" # Directory holding public keys to be used on each machine
 
 # Kubernetes - Cluster
-cluster_version        = "1.22.10"                       # Kubernetes version
+cluster_version        = "1.23.8"                       # Kubernetes version
 cluster_cni            = "calico"                        # Kubernetes Container Network Interface (CNI)
 cluster_cri            = "containerd"                    # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.35.0.0/16"                  # Kubernetes service subnet

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.22.10"      # Kubernetes Version
+cluster_version        = "1.23.8"      # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.22.10"      # Kubernetes Version
+cluster_version        = "1.23.8"      # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.22.10"      # Kubernetes Version
+cluster_version        = "1.23.8"      # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.22.10"      # Kubernetes Version
+cluster_version        = "1.23.8"      # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/variables.tf
+++ b/variables.tf
@@ -294,7 +294,7 @@ variable "cluster_domain" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.22.10"
+  default = "1.23.8"
 }
 
 variable "cluster_cni" {


### PR DESCRIPTION
### Change
Update default K8s version to 1.23.8, this is order to be within the +/- range of K8s 1.24.

### Tests

| Scenario | K8s Version | Order  | Cadence   | Deployment Success |
| -------- | ----------- | ------ | --------- | ------------------ |
| 1        | 1.24.3      | *| fast:2020 | yes                |
| 2        | 1.22.12     | *| fast:2020 | yes                |



























































