### PR TITLE
feat: (IAC-669) Update Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base layer
-FROM ubuntu:20.04 as baseline
+FROM ubuntu:22.04 as baseline
 RUN apt update && apt upgrade -y \
   && apt install -y python3 python3-dev python3-pip curl unzip gnupg \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \


### PR DESCRIPTION
### Changes
Update the base image to ubuntu:22.04

### Tests
I was able to successfully build an image with the updated Dockerfile and use it to create my infrastructure. See internal ticket for more details. 