### PR TITLE
docs: (IAC-864) Update SAS Viya name in documentation

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -71,7 +71,7 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| cluster_version        | Kubernetes version | string | "1.23.8" | Valid values are listed here: [SAS Viya Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
+| cluster_version        | Kubernetes version | string | "1.23.8" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
 | cluster_cni            | Kubernetes container network interface (CNI) | string | "calico" | |
 | cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.24.5" | |
 | cluster_cri            | Kubernetes container runtime interface (CRI) | string | "containerd" | |
@@ -115,7 +115,7 @@ Node pools are maps of objects. They represent information about each pool type,
 | node_taints |  | list(string) | | |
 | node_labels |  | map(string) | | |
 
-There is no default type for SAS Viya node pools. However, examples that are based on SAS recommendations are listed in the example files. Below is a sample of a basic cluster `node_pools` definition that you could use in your terraform.tfvars file.
+There is no default type for SAS Viya platform node pools. However, examples that are based on SAS recommendations are listed in the example files. Below is a sample of a basic cluster `node_pools` definition that you could use in your terraform.tfvars file.
 
 **NOTE**: These node pools are required for the `node_pools` variable:
 
@@ -292,7 +292,7 @@ nfs_ip        = ""    # Assigned values for static IP addresses
 
 1. If you enable `server_ssl` without defining either `server_ssl_cert_file` or `server_ssl_cert_file`, the system's default SSL certificate and key are used instead. By default, on Ubuntu systems we create a copy of those files and name them `ssl-cert-sas-${PG_HOST}.pem` and `ssl-cert-sas-${PG_HOST}.key`.
     - The Ansible tasks that are performed include copying the certificate and key from the PostgreSQL VM into your local workspace directory.
-2. If you are planning to use the [viya4-deployment repository](https://github.com/sassoftware/viya4-deployment) to perform a SAs Viya deployment where you have [full-stack TLS](https://github.com/sassoftware/viya4-deployment/blob/main/docs/CONFIG-VARS.md#tls) configured, make sure that the `V4_CFG_TLS_TRUSTED_CA_CERTS` variable in the viya4-deployment ansible-vars.yaml file points to a directory that contains the server_ssl_cert_file.
+2. If you are planning to use the [viya4-deployment repository](https://github.com/sassoftware/viya4-deployment) to perform a SAS Viya platform deployment where you have [full-stack TLS](https://github.com/sassoftware/viya4-deployment/blob/main/docs/CONFIG-VARS.md#tls) configured, make sure that the `V4_CFG_TLS_TRUSTED_CA_CERTS` variable in the viya4-deployment ansible-vars.yaml file points to a directory that contains the server_ssl_cert_file.
 
 Sample:
 
@@ -316,7 +316,7 @@ postgres_servers = {
 
 ### Ansible ansible-vars.yaml File
 
-The following variables are used to describe the machine targets for the SAS Viya deployment.
+The following variables are used to describe the machine targets for the SAS Viya platform deployment.
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
@@ -397,7 +397,7 @@ node_taints:
 
 ### Ansible inventory file
 
-The inventory file represents the machines that you will be using in your Kubernetes deployment of SAS Viya. An example and information about this file can be found [here](../examples/bare-metal/sample-inventory).
+The inventory file represents the machines that you will be using in your Kubernetes deployment of the SAS Viya platform. An example and information about this file can be found [here](../examples/bare-metal/sample-inventory).
 
 ## Storage
 
@@ -426,7 +426,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 | :--- | ---: | ---: | ---: | ---: |
 | administrator_login | The administrator login account for the PostgreSQL server. Changing this forces a new resource to be created. | string | "pgadmin" | | |
 | administrator_password | The password associated with the administrator_login for the PostgreSQL server | string | "my$up3rS3cretPassw0rd" |  |
-| server_version | The version of the PostgreSQL server | string | "13" | Refer to the [Viya 4 System Requirements](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for SAS Viya. |
+| server_version | The version of the PostgreSQL server | string | "13" | Refer to the [SAS Viya platform System Requirements](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
 | ssl_enforcement_enabled | Enforce SSL on connections to the PostgreSQL database | bool | true | |
 
 Here is an example of the `postgres_servers` variable where the `default` entry only overrides the `administrator_password` parameter, and the `another-server` entry overrides all parameters:

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -27,7 +27,7 @@ Table of Contents
 
 ## Operating System
 
-An Ubuntu Linux operating system is required for the machine that uses the tools in this repository to perform the tasks associated with standing up infrastructure for a SAS Viya deployment.
+An Ubuntu Linux operating system is required for the machine that uses the tools in this repository to perform the tasks associated with standing up infrastructure for a SAS Viya platform deployment.
 
 | Operating System | Description |
 | --- | --- |
@@ -35,9 +35,9 @@ An Ubuntu Linux operating system is required for the machine that uses the tools
 
 ## Machines
 
-The following table lists the minimum machine requirements that are needed to support a Kubernetes cluster and supporting elements for a SAS Viya 4 software installation. These machines must be running a recent version of Linux and must all be on the same network. Each machine should have a DNS entry associated with its assigned IP address; this is not required, but it makes setup easier.
+The following table lists the minimum machine requirements that are needed to support a Kubernetes cluster and supporting elements for a SAS Viya platform software installation. These machines must be running a recent version of Linux and must all be on the same network. Each machine should have a DNS entry associated with its assigned IP address; this is not required, but it makes setup easier.
 
-**NOTE**: The PostgreSQL server that is described in the following table is listed as 1 machine. If you plan to use the internal PostgreSQL server for SAS Viya, this server is not required, but you will need to adjust the capacity of your compute nodes in order to ensure that they can handle the resource requirements of the PostgreSQL processes.
+**NOTE**: The PostgreSQL server that is described in the following table is listed as 1 machine. If you plan to use the internal PostgreSQL server for the SAS Viya platform, this server is not required, but you will need to adjust the capacity of your compute nodes in order to ensure that they can handle the resource requirements of the PostgreSQL processes.
 
 | Machine | CPU | Memory | Disk | Information | Minimum Count |
 | ---: | ---: | ---: | ---: | --- | ---: |
@@ -45,7 +45,7 @@ The following table lists the minimum machine requirements that are needed to su
 | **Nodes** | xx | xx GB | xx GB | Nodes in the Kubernetes cluster. The number of machines varies, depending on multiple factors. Suggested capacities and information can be found in the sample files. | 3 |
 | **Jump Server** | 4 | 8 GB | 100 GB | Bastion box that is used to access NFS mounts, share data, etc. | 1 |
 | **NFS Server** | 8 | 16 GB | 500 GB | Required server that is used to store persistent volumes for the cluster. Used for providing storage for the `default` storage class in the cluster. | 1 |
-| **PostgreSQL Servers** | 8 | 16 GB | 250 GB | PostgreSQL servers for your SAS Viya deployment. | 1..n |
+| **PostgreSQL Servers** | 8 | 16 GB | 250 GB | PostgreSQL servers for your SAS Viya platform deployment. | 1..n |
 
 ### VMware vSphere or vCenter
 
@@ -74,7 +74,7 @@ The current repository supports the provisioning of vSphere VMs. The following t
 
 ### Physical Machines or Linux VMs
 
-In order to provision physical machines for a SAS Viya deployment, you must set up ALL systems with the required elements that were listed previously. These systems must have full network access to each other.
+In order to provision physical machines for a SAS Viya platform deployment, you must set up ALL systems with the required elements that were listed previously. These systems must have full network access to each other.
 
 ## Network
 
@@ -109,7 +109,7 @@ These IP addresses are part of your network but are not assigned. Floating IP ad
 
 ## Storage
 
-This section outlines how storage is used by the tooling to create the `local-storage` storage class for use in kubernetes. Currently there are two such products that are used in the SAS Viya 4 system that require local storage, these are **OpenSearch** and **SingleStore**. If these products are going to be in use within your cluster you will need to have local storage active.
+This section outlines how storage is used by the tooling to create the `local-storage` storage class for use in kubernetes. Currently there are two such products that are used in the SAS Viya platform system that require local storage, these are **OpenSearch** and **SingleStore**. If these products are going to be in use within your cluster you will need to have local storage active.
 
 ### Configuration and Restrictions
 
@@ -172,7 +172,7 @@ This section provides an example configuration based on the physical-machine and
 
 ### vCenter/vSphere Sample tfvars File
 
-If you are creating virtual machines with vCenter or vSphere, the terraform.tfvars file that you create will generate the required inventory and ansible-vars.yaml files for a SAS Viya deployment using the tools in the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) repository.
+If you are creating virtual machines with vCenter or vSphere, the terraform.tfvars file that you create will generate the required inventory and ansible-vars.yaml files for a SAS Viya platform deployment using the tools in the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) repository.
 
 For this example, the network setup is as follows:
 
@@ -640,7 +640,7 @@ cr_ip   : ""
 
 ## Deployment
 
-The following items **MUST** be added to your ansible-vars.yaml file if you are using the [viya4-deployment](https://github.com/sassoftware/viya4-deployment.git) repository to deploy SAS Viya.
+The following items **MUST** be added to your ansible-vars.yaml file if you are using the [viya4-deployment](https://github.com/sassoftware/viya4-deployment.git) repository to deploy the SAS Viya platform.
 
 You must adjust the `externalTrafficPolicy` value based on the load balancer selection chosen. The valid values are listed below:
 
@@ -668,7 +668,7 @@ NFS_CLIENT_NAME: nfs-subdir-external-provisioner-sas
 
 ## Third-Party Tools
 
-The third-party applications that are listed in the following table are supported for the deployment of SAS Viya into a cluster configured by viya4-iac-kubernetes:
+The third-party applications that are listed in the following table are supported for the deployment of the SAS Viya platform into a cluster configured by viya4-iac-kubernetes:
 
 | Application | Minimum Version |
 | ---: | ---: |


### PR DESCRIPTION
### Changes
Updating the SAS Viya name in the documentation

### Note: 

The repo's "About" section will also need to change as part of this PR, since that's not controlled by the code I'll put the updated content here. Please review this as well.

>This project contains Terraform scripts to provision cloud infrastructure resources, when using vSphere, and Ansible to apply the needed elements of a Kubernetes cluster that are required to deploy SAS Viya platform product offerings. 
