### PR TITLE
feat: (IAC-902) Update default K8s version to 1.24.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && apt upgrade -y \
 # Layers used for building/downloading/installing tools
 FROM baseline as tool_builder
 ARG HELM_VERSION=3.10.0
-ARG KUBECTL_VERSION=1.23.8
+ARG KUBECTL_VERSION=1.24.10
 ARG TERRAFORM_VERSION=1.3.2
 
 WORKDIR /build

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -71,7 +71,7 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| cluster_version        | Kubernetes version | string | "1.23.8" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
+| cluster_version        | Kubernetes version | string | "1.24.10" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
 | cluster_cni            | Kubernetes container network interface (CNI) | string | "calico" | |
 | cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.24.5" | |
 | cluster_cri            | Kubernetes container runtime interface (CRI) | string | "containerd" | |
@@ -329,7 +329,7 @@ The following variables are used to describe the machine targets for the SAS Viy
 | prefix | A prefix used in the names of all the resources created by this script | string | | |
 | deployment_type | Type of deployment to be performed | string | "bare_metal" | Specify `bare_metal` or `vsphere`. |
 | kubernetes_cluster_name | Cluster name | string | "{{ prefix }}-oss" | This item is auto-filled. **ONLY** change the `prefix` value described previously. |
-| kubernetes_version | Kubernetes version | string | "1.23.8" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
+| kubernetes_version | Kubernetes version | string | "1.24.10" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
 | kubernetes_upgrade_allowed | | bool | true | **NOTE:** Not currently used. |
 | kubernetes_arch | | string | "{{ vm_arch }}" | This item is auto-filled. **ONLY** change the `vm_arch` value described previously. |
 | kubernetes_cni | Kubernetes Container Network Interface (CNI) | string | "calico" | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -340,7 +340,7 @@ The following variables are used to describe the machine targets for the SAS Viy
 | kubernetes_vip_version | kube-vip version | string | "0.5.7" | |
 | kubernetes_vip_ip | kube-vip IP address | string | | |
 | kubernetes_vip_fqdn | kube-vip DNS | string | | |
-| kubernetes_loadbalancer | Load balancer provider | string | "kube_vip" | Choices are `kube_vip` or `metallb`.
+| kubernetes_loadbalancer | Load balancer provider | string | "kube_vip" | Choices are `kube_vip` or `metallb`. |
 | kubernetes_loadbalancer_addresses | Load balancer IP addresses | string | [] | Values depend on the load balancer that is selected. [This link](https://kube-vip.io/docs/usage/cloud-provider/#the-kube-vip-cloud-provider-configmap) provides more information about kube-vip load balancer addresses. [This link](https://metallb.universe.tf/configuration/#layer-2-configuration) provides more information about MetalLB load balancer addresses. |
 | node_labels | Labels applied to nodes in your cluster | map(list(string)) | | See [Labels/Taints](#labelstaints) below for more information. |
 | node_taints | Taints applied to nodes in your cluster | map(list(string)) | | See [Labels/Taints](#labelstaints) below for more information. |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -205,7 +205,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh" # Directory holding public keys to be used on each machine
 
 # Kubernetes - Cluster
-cluster_version        = "1.23.8"                        # Kubernetes version
+cluster_version        = "1.24.10"                        # Kubernetes version
 cluster_cni            = "calico"                        # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"                        # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"                    # Kubernetes Container Runtime Interface (CRI)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -115,7 +115,7 @@ This section outlines how storage is used by the tooling to create the `local-st
 
 1. The disks must be represented as empty partitions - `/dev/sdb`, `/dev/sdc`, etc. and attached to the machine or VM.
 2. The empty partitions cannot be formatted or pre-configured. These partitions must simply be attached and in their raw state.
-3. You must supply an empty partition for each local storage entity needed. Currently if your deployment will include any products that utilize **OpenSearch** or **SingleStore**, you'll need need to have these disks available for use.
+3. You must supply an empty partition for each local storage entity needed. Currently if your deployment will include any products that utilize **OpenSearch** or **SingleStore**, you'll need to have these disks available for use.
 4. You will need to update ANY transformer being used for the **OpenSearch** or **SingleStore** products to mirror these values. Using `local-storage` as the storage class and adjusting the storage size to mirror the partition created for use.
 
 ### Bare metal and virtual machine storage example
@@ -172,7 +172,7 @@ This section provides an example configuration based on the physical-machine and
 
 ### vCenter/vSphere Sample tfvars File
 
-If you are creating virtual machines with vCenter or vSphere, the terraform.tfvars file that you create will generate the required inventory and ansible-vars.yaml files for a SAS Viya platform deployment using the tools in the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) repository.
+If you are creating virtual machines with vCenter or vSphere, the terraform .tfvars file that you create will generate the required inventory and ansible-vars.yaml files for a SAS Viya platform deployment using the tools in the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) repository.
 
 For this example, the network setup is as follows:
 

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.23.8"       # Kubernetes Version
+cluster_version        = "1.24.10"       # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -19,8 +19,8 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.24.10"       # Kubernetes Version
-cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
+cluster_version        = "1.24.10"      # Kubernetes Version
+cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
@@ -85,7 +85,7 @@ control_plane_ssh_key_name = "cp_ssh"
 #
 node_pools = {
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   control_plane = {
     count       = 3
     cpus        = 2
@@ -95,7 +95,7 @@ node_pools = {
     node_labels = {}
   },
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   system = {
     count       = 1
     cpus        = 8

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -19,8 +19,8 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.24.10"       # Kubernetes Version
-cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
+cluster_version        = "1.24.10"      # Kubernetes Version
+cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
@@ -86,7 +86,7 @@ control_plane_ssh_key_name = "cp_ssh"
 cluster_node_pool_mode = "minimal"
 node_pools = {
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   control_plane = {
     count       = 1
     cpus        = 2
@@ -96,7 +96,7 @@ node_pools = {
     node_labels = {}
   },
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   system = {
     count       = 1
     cpus        = 8

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.23.8"       # Kubernetes Version
+cluster_version        = "1.24.10"       # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -19,8 +19,8 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.24.10"       # Kubernetes Version
-cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
+cluster_version        = "1.24.10"      # Kubernetes Version
+cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
@@ -85,7 +85,7 @@ control_plane_ssh_key_name = "cp_ssh"
 #
 node_pools = {
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   control_plane = {
     cpus    = 2
     memory  = 4096
@@ -99,7 +99,7 @@ node_pools = {
     node_labels = {}
   },
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   system = {
     cpus    = 8
     memory  = 16384

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.23.8"       # Kubernetes Version
+cluster_version        = "1.24.10"       # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-static-singlestore.tfvars
+++ b/examples/vsphere/sample-terraform-static-singlestore.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.23.8"       # Kubernetes Version
+cluster_version        = "1.24.10"       # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-static-singlestore.tfvars
+++ b/examples/vsphere/sample-terraform-static-singlestore.tfvars
@@ -19,8 +19,8 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.24.10"       # Kubernetes Version
-cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
+cluster_version        = "1.24.10"      # Kubernetes Version
+cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
@@ -91,7 +91,7 @@ control_plane_ssh_key_name = "cp_ssh"
 #
 node_pools = {
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   control_plane = {
     cpus    = 2
     memory  = 4096
@@ -105,7 +105,7 @@ node_pools = {
     node_labels = {}
   },
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   system = {
     cpus    = 8
     memory  = 16384

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -19,8 +19,8 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.24.10"       # Kubernetes Version
-cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
+cluster_version        = "1.24.10"      # Kubernetes Version
+cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
@@ -85,7 +85,7 @@ control_plane_ssh_key_name = "cp_ssh"
 #
 node_pools = {
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   control_plane = {
     count       = 1
     cpus        = 2
@@ -95,7 +95,7 @@ node_pools = {
     node_labels = {}
   },
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
-  #                      Other varaibles may be altered
+  #                      Other variables may be altered
   system = {
     count       = 1
     cpus        = 8

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -19,7 +19,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.23.8"       # Kubernetes Version
+cluster_version        = "1.24.10"       # Kubernetes Version
 cluster_cni            = "calico"       # Kuberentes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/variables.tf
+++ b/variables.tf
@@ -294,7 +294,7 @@ variable "cluster_domain" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.23.8"
+  default = "1.24.10"
 }
 
 variable "cluster_cni" {


### PR DESCRIPTION
### Changes

Since the SAS Viya Platform will be supporting K8s 1.23, 1.24, and 1.25 in March as part of the 2023.03 cadence, the kubectl and cluster_version version is being changed to 1.24.10 so that it's within the +/- 1 range of the supported versions. 

### Tests

| Scenario | Task | Provider | Order  | Cadence        | cluster_version | Orchestration       | Deployment Method	 Version | kubectl Version | INGRESS_NGINX_CHART_VERSION |
|:---------|:-----|:---------|:-------|:---------------|:----------------|:--------------------|:---------------------------|:----------------|:----------------------------|
| 1        | OOTB | vmware   | *| stable:2023.01 | 1.24.10         | Deployment Operator | Docker                     | 1.24.10         | 4.3.0                       |
| 2        | OOTB | vmware   | *| fast:2020      | 1.25.6          | Deployment Operator | Docker                     | 1.25.6          | 4.3.0                       |