### PR TITLE
docs: (IAC-916) V4M monitoring and logging fails to install with open-source K8s because of the missing v4m SC

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -664,14 +664,13 @@ INGRESS_NGINX_CONFIG:
 ### NFS Subdir External Provisioner - SAS default storage class
 # Updates to support open source Kubernetes 
 NFS_CLIENT_NAME: nfs-subdir-external-provisioner-sas
-```
 
-You must explicitly set the value for `V4M_STORAGECLASS` in your ansible-vars.yaml file as shown below to a pre-existing Storage Class (for example: `local-storage`) prior to installing `cluster-logging` or `cluster-monitoring` with [viya4-deployment](https://github.com/sassoftware/viya4-deployment.git).
-
-```yaml
 ## Logging and Monitoring
 V4M_STORAGECLASS = local-storage
 ```
+
+You must explicitly set the value for `V4M_STORAGECLASS` in your ansible-vars.yaml file as shown above to a pre-existing Storage Class (for example: `local-storage`) prior to installing `cluster-logging` or `cluster-monitoring` with [viya4-deployment](https://github.com/sassoftware/viya4-deployment.git).
+
 While other storage classes can be used, the `local-storage` class is **recommended** for the Viya Monitoring and Logging tools.
 
 ## Third-Party Tools


### PR DESCRIPTION
# Changes
Adds required instructions for setting `V4M_STORAGECLASS` value to `local-storage` in ansible-vars.yaml when using [viya4-deployment](https://github.com/sassoftware/viya4-deployment.git) to deploy `cluster-logging` and `cluster-monitoring` applications.