### PR TITLE
docs: (IAC-716) provide inventory sample without postgres host groups

### DIFF
--- a/examples/bare-metal/sample-inventory-internal-postgres
+++ b/examples/bare-metal/sample-inventory-internal-postgres
@@ -1,0 +1,75 @@
+# This example file has the postgres host groups omitted
+# Use this file if you are planning on performing a SAS Viya Platform
+# deployment with internal postgres.
+
+#
+# Kubernetes - Control Plane nodes
+#
+# This list is the FQDN/IP of the nodes used for the control plane
+#
+# NOTE: For HA/kube-vip to work you need at least 3 nodes
+#
+[k8s_control_plane]
+FIXME - ENTER YOUR KUBERNETES CONTROL PLANE NODE IPs/FQDNs HERE!
+
+#
+# Kubernetes - Nodes
+#
+# This list is the FQDN/IP of the nodes used for the generic nodes
+#
+# NOTE: For HA to work you need at least 3 nodes
+#
+[k8s_node]
+FIXME - ENTER YOUR KUBERNETES COMPUTE NODE IPs/FQDNs HERE!
+
+#
+# Kubernetes Nodes - alias - DO NOT MODIFY
+#
+[k8s:children]
+k8s_control_plane
+k8s_node
+
+#
+# Jump Server
+#
+[jump_server]
+FIXME - ENTER YOUR JUMP SERVER IP/FQDN HERE!
+
+#
+# Jump Server - alias - DO NOT MODIFY
+#
+[jump:children]
+jump_server
+
+#
+# NFS Server
+#
+[nfs_server]
+FIXME - ENTER YOUR NFS SERVER IP/FQDN HERE!
+
+#
+# NFS Server - alias - DO NOT MODIFY
+#
+[nfs:children]
+nfs_server
+
+#
+# Container Registry
+#
+[cr_server]
+FIXME - ENTER YOUR CR SERVER IP/FQDN HERE!
+
+#
+# Container Registry - alias - DO NOT MODIFY
+#
+[cr:children]
+cr_server
+
+#
+# All systems
+#
+[all:children]
+k8s
+jump
+nfs
+cr


### PR DESCRIPTION
### Changes
Created a sample inventory file at `examples/bare-metal/sample-inventory-internal-postgres` that users can use if they do not want to configured a machine to be an external postgres instance.

### Tests

Provisioned some instances in vcenter and ran through a "setup install" after filling out an inventory file that did not have the postgres hostgroups defined. I saw that the postgres tasks were correctly skipped and did not result in an error. Afterwards I used viya4-deployment to perform a deployment that has an internal postgres configured.

* Provider: oss
* K8s Version: v1.25.6
* Order: *
* Cadence: fast:2020
* Postgres: internal
* Orchestration: deployment operator

See internal ticket for more details