### PR TITLE
feat: (IAC-1114) Use the 'search' test rather than find when checking node names for labelling purposes

### DIFF
--- a/roles/kubernetes/node/labels_taints/tasks/main.yaml
+++ b/roles/kubernetes/node/labels_taints/tasks/main.yaml
@@ -8,7 +8,7 @@
   vars:
     labels: "{{ item.value }}"
   with_dict: "{{ node_labels }}"
-  when: ansible_nodename.find(item.key) != -1
+  when: ansible_nodename is search(item.key)
   tags:
     - install
     - update
@@ -19,7 +19,7 @@
   vars:
     taints: "{{ item.value }}"
   with_dict: "{{ node_taints }}"
-  when: ansible_nodename.find(item.key) != -1
+  when: ansible_nodename is search(item.key)
   tags:
     - install
     - update


### PR DESCRIPTION
For some of our baremetal clusters, the node names don't adhere to the naming conventions this project appears to expect, so node labelling and tainting doesn't work as desired.

Swapping to using the ansible 'search' test would behave the same as 'find' for simple substring searches, but would also allow for using regular expressions. That gives more options in setting the key values (e.g. '.+' to label all nodes for compute).