### PR TITLE
feat: (IAC-1113) Add node labels and taints with a label selector matching on both the short and long hostname

### DIFF
--- a/roles/kubernetes/node/labels_taints/tasks/labels.yaml
+++ b/roles/kubernetes/node/labels_taints/tasks/labels.yaml
@@ -4,7 +4,7 @@
 ---
 - name: Applying labels
   ansible.builtin.shell: |
-    kubectl label nodes {{ ansible_hostname }} {{ label }} --overwrite
+    kubectl label nodes -l 'kubernetes.io/hostname in ({{ ansible_hostname }},{{ ansible_fqdn }})' {{ label }} --overwrite
   with_items: "{{ labels }}"
   loop_control:
     loop_var: label

--- a/roles/kubernetes/node/labels_taints/tasks/taints.yaml
+++ b/roles/kubernetes/node/labels_taints/tasks/taints.yaml
@@ -4,7 +4,7 @@
 ---
 - name: Applying taints
   ansible.builtin.shell: |
-    kubectl taint nodes {{ ansible_hostname }} {{ taint }} --overwrite
+    kubectl taint nodes -l 'kubernetes.io/hostname in ({{ ansible_hostname }},{{ ansible_fqdn }})' {{ taint }} --overwrite
   with_items: "{{ taints }}"
   loop_control:
     loop_var: taint


### PR DESCRIPTION
The current node labelling and tainting code uses the **ansible_hostname** magic variable, which resolves to the node's short hostname. However, when nodes join the cluster, they seem to join based on the output of 'hostname'. On some environments that may resolve to the long hostname. In that case, the node names returned from **kubectl get nodes** will be the FQDN, but the label/taint code will be trying to label based on the short hostname, which will ultimately fail.

The proposed change adjusts the label/taint behavior to select the node using a label selector, which will match on both the short and long hostname.