### PR TITLE
feat!: (IAC-971) Update Terraform Version to 1.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
   && curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod 755 ./kubectl \
   && curl -ksLO https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 755 get-helm-3 \
   && ./get-helm-3 --version v$HELM_VERSION --no-sudo \
-  && apt-get install terraform=$TERRAFORM_VERSION
+  && apt-get install -y terraform=$TERRAFORM_VERSION
 
 # Installation steps
 FROM baseline

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt upgrade -y \
 FROM baseline as tool_builder
 ARG HELM_VERSION=3.10.0
 ARG KUBECTL_VERSION=1.25.8
-ARG TERRAFORM_VERSION=1.3.2
+ARG TERRAFORM_VERSION=1.4.5
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt upgrade -y \
 FROM baseline as tool_builder
 ARG HELM_VERSION=3.10.0
 ARG KUBECTL_VERSION=1.25.8
-ARG TERRAFORM_VERSION=1.4.5
+ARG TERRAFORM_VERSION=1.4.5-*
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This project supports the following options for running the scripts in this repo
 
 The following software is required in order to run the SAS Viya IaC tools here on your local system:
 
-- [Terraform](https://www.terraform.io/downloads) - v.1.3.2
+- [Terraform](https://www.terraform.io/downloads) - v1.4.5
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) - v2.13.4
 - [Docker](https://docs.docker.com/engine/install/) - v20.10.17
 - [Helm](https://helm.sh/docs/intro/install/) - v3.10.0

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -682,6 +682,6 @@ The third-party applications that are listed in the following table are supporte
 | Application | Minimum Version |
 | ---: | ---: |
 | [Ansible](https://www.ansible.com/) | Core 2.13.4 |
-| [Terraform](https://www.terraform.io/) |1.3.2 |
+| [Terraform](https://www.terraform.io/) | 1.4.5 |
 | [Docker](https://www.docker.com/) | 20.10.17 |
 | [Helm](https://helm.sh/) | 3.10.0 |

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.4.5"
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 terraform {
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.4.5"
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 terraform {
-  required_version = ">= 1.4.5"
+  required_version = ">= 1.4.0"
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"


### PR DESCRIPTION
### Changes

Updated the default and minimum required Terraform version to 1.4.5, to pull in the latest features, fixes, and security patches from HashiCorp.

Consumers of the Dockerfile will already have the version updated within the installation stages. For users that are running viya4-iac-k8s directly on their machine without the use of the Docker container (by executing the `oss-k8s.sh` or `terraform`)should update their terraform version to at least 1.4.5.

Users who have previously created OSS infrastructure with viya4-iac-k8s releases 2.3.0 or earlier should still be able to manage their infrastructure after updating the terraform version to 1.4.5.


### Tests
| Scenario | Provider | kubernetes_version | kubectl version | Deployment Method | Terraform Version | Order  | Cadence   | Notes                               |
| -------- | -------- | ------------------ | --------------- | ----------------- | ----------------- | ------ | --------- | ----------------------------------- |
| 1        | OSS      | 1.25.8             | 1.25.8          | Docker            | v1.4.5            | * | fast:2020 | baseline,viya,install               |
| 2        | OSS      | 1.25.8             | 1.25.8          | Local Terraform   | v1.4.5            | n/a    | n/a       | only tested infrastructure creation |