### PR TITLE
fix: (IAC-1027) Sample Inventory file for bare metal is incorrect

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -431,7 +431,7 @@ The following variables are used to describe the machine targets for the SAS Viy
 
 | Name | Description | Type | Notes |
 |:---|---:|---:|---:|
-| postgres_server_name | Name of the PostgresSQL server | string | |
+| postgres_server_name | Name of the PostgreSQL server | string | |
 | postgres_server_version | The version of the PostgreSQL server | string | Refer to the [SAS Viya Platform Administration Guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
 | postgres_server_ssl | Enable/disable SSL | string | Specify `off` or `on` |
 | postgres_server_ssl_cert_file | Path to the PostgreSQL SSL certificate file | string | If `postgres_server_ssl` is enabled and this variable is not defined, the system default SSL certificate is used. |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -431,7 +431,7 @@ The following variables are used to describe the machine targets for the SAS Viy
 
 | Name | Description | Type | Notes |
 |:---|---:|---:|---:|
-| postgres_ip | Static IP address for PostgreSQL server | string | This field is required if you are configuring a PostgreSQL server |
+| postgres_server_name | Name of the PostgresSQL server | string | |
 | postgres_server_version | The version of the PostgreSQL server | string | Refer to the [SAS Viya Platform Administration Guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
 | postgres_server_ssl | Enable/disable SSL | string | Specify `off` or `on` |
 | postgres_server_ssl_cert_file | Path to the PostgreSQL SSL certificate file | string | If `postgres_server_ssl` is enabled and this variable is not defined, the system default SSL certificate is used. |

--- a/examples/bare-metal/sample-inventory
+++ b/examples/bare-metal/sample-inventory
@@ -69,7 +69,7 @@ cr_server
 [<postgres_server_name>]
 FIXME - ENTER YOUR POSTGRES SERVER IP/FQDN HERE!
 [<postgres_server_name>:vars]
-postgres_ip="<postgres_server_ip>"
+postgres_server_name="<postgres_server_name>"
 postgres_server_version="<postgres_server_version>"
 postgres_server_ssl="<postgres_server_ssl_enabled" # NOTE: Values - [on,off]
 postgres_administrator_login="postgres" # NOTE: Do not change this value at this time


### PR DESCRIPTION
### Changes
Update the sample inventory file that we provide for bare metal.

`postgres_ip` is not a valid field and instead should be replaced with `postgres_server_name`



### Tests

| Scenario | Provider | Type       | kubernetes_version | kubectl version | Deployment Method | Terraform Version |
|----------|----------|------------|--------------------|-----------------|-------------------|-------------------| 
| 1        | OSS      | bare metal | 1.25.8             | 1.25.8          | Docker            | v1.4.5        