### PR TITLE
fix: (IAC-1042) Fix kubernetes-xenial APT Repo Public Key Error

### DIFF
--- a/roles/kubernetes/toolbox/tasks/main.yaml
+++ b/roles/kubernetes/toolbox/tasks/main.yaml
@@ -21,7 +21,7 @@
   ansible.builtin.copy:
     dest: /etc/apt/sources.list.d/kubernetes.list
     content: |
-      deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main
+      deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg trusted=yes] https://apt.kubernetes.io/ kubernetes-xenial main
   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")
   tags:
     - install


### PR DESCRIPTION
### Changes

Adds `trusted=yes` to the kubernetes-xenial APT repo entry in `/etc/apt/sources.list.d/kubernetes.list` to get around this open Kubernetes issue https://github.com/kubernetes/release/issues/2862

### Tests

After the changes went in recreated my infrastructure in vsphere and ran setup, install. I verified that I no longer ran into the failure during the `kubernetes/toolbox : Update apt package index and install kubelet, kubeadm, kubectl` task and I was able to use kubectl to check my cluster.

| Scenario | Provider | Type     | kubernetes_version | kubectl version | Deployment Method | OS           | Notes                               |
|----------|----------|----------|--------------------|-----------------|-------------------|--------------|-------------------------------------| 
| 1        | OSS      | vpshere  | 1.25.8             | 1.25.8          | Docker            | ubuntu 22.04 | No longer ran into the task failure |