### PR TITLE
fix: (IAC-1019) Use apt-get tool in Dockerfile per hadolint recommendation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Base layer
 FROM ubuntu:22.04 as baseline
-RUN apt update && apt upgrade -y \
-  && apt install -y python3 python3-dev python3-pip curl unzip gnupg \
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install -y python3 python3-dev python3-pip curl unzip gnupg \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
-  && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+  && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Layers used for building/downloading/installing tools
 FROM baseline as tool_builder
@@ -15,16 +16,18 @@ WORKDIR /build
 
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
   && echo "deb [arch=amd64] https://apt.releases.hashicorp.com focal main" > /etc/apt/sources.list.d/tf.list \
-  && apt update \
+  && apt-get update \
   && curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod 755 ./kubectl \
   && curl -ksLO https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 755 get-helm-3 \
   && ./get-helm-3 --version v$HELM_VERSION --no-sudo \
-  && apt-get install -y terraform=$TERRAFORM_VERSION
+  && apt-get install -y terraform=$TERRAFORM_VERSION \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Installation steps
 FROM baseline
 
-RUN apt -y install git sshpass jq
+RUN apt-get update && apt-get -y install git sshpass jq \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tool_builder /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=tool_builder /build/kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
# Dockerfile changes

- Use apt-get tool versus apt per hadolint warning
- Add apt-get clean and apt/lists/* removal for each use of apt-get update

# Tests

See internal ticket for command output details and terraform.tfvars file.
 * Built new image with the proposed Dockerfile changes
 * Verified the registration of internal DNS entries for ingress and kubevip, jump vm, nfs server and postgres server
 * Created the k8s infrastructure in vsphere using the updated internal image with the following command

```
docker run --rm -it \
  --group-add root \
  --user $(id -u):$(id -g) \
  --env-file $HOME/.vsphere_docker_creds.env \
  --volume $(pwd):/workspace \
  viya4-iac-k8s apply setup install

```

 * Queried infrastructure with generated kubeconfig file to verify nodes were successfully created at the indicated k8s version.
 * Verified that destroy tag successfully removes the created infrastructure