### PR TITLE
feat: (IAC-1046) Add Support for K8s 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 # Layers used for building/downloading/installing tools
 FROM baseline as tool_builder
 ARG HELM_VERSION=3.12.0
-ARG KUBECTL_VERSION=1.25.8
+ARG KUBECTL_VERSION=1.26.7
 ARG TERRAFORM_VERSION=1.4.5-*
 
 WORKDIR /build

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -69,7 +69,7 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| cluster_version        | Kubernetes version | string | "1.25.8" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
+| cluster_version        | Kubernetes version | string | "1.26.7" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://go.documentation.sas.com/doc/en/itopscdc/default/itopssr/n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
 | cluster_cni            | Kubernetes container network interface (CNI) | string | "calico" | |
 | cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.24.5" | |
 | cluster_cri            | Kubernetes container runtime interface (CRI) | string | "containerd" | |
@@ -351,7 +351,7 @@ The following variables are used to describe the machine targets for the SAS Viy
 | prefix | A prefix used in the names of all the resources created by this script | string | | |
 | deployment_type | Type of deployment to be performed | string | "bare_metal" | Specify `bare_metal` or `vsphere`. |
 | kubernetes_cluster_name | Cluster name | string | "{{ prefix }}-oss" | This item is auto-filled. **ONLY** change the `prefix` value described previously. |
-| kubernetes_version | Kubernetes version | string | "1.25.8" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
+| kubernetes_version | Kubernetes version | string | "1.26.7" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
 | kubernetes_upgrade_allowed | | bool | true | **NOTE:** Not currently used. |
 | kubernetes_arch | | string | "{{ vm_arch }}" | This item is auto-filled. **ONLY** change the `vm_arch` value described previously. |
 | kubernetes_cni | Kubernetes Container Network Interface (CNI) | string | "calico" | |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -203,7 +203,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh" # Directory holding public keys to be used on each machine
 
 # Kubernetes - Cluster
-cluster_version        = "1.25.8"                        # Kubernetes version
+cluster_version        = "1.26.7"                        # Kubernetes version
 cluster_cni            = "calico"                        # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"                        # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"                    # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.25.8"       # Kubernetes Version
+cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.25.8"       # Kubernetes Version
+cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.25.8"       # Kubernetes Version
+cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-static-singlestore.tfvars
+++ b/examples/vsphere/sample-terraform-static-singlestore.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.25.8"       # Kubernetes Version
+cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.25.8"       # Kubernetes Version
+cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
+++ b/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
@@ -7,7 +7,7 @@ LOCAL_VOLUME_NAME: sig-storage-local-static-provisioner-sas
 LOCAL_VOLUME_NAMESPACE: kube-system
 LOCAL_VOLUME_CHART_NAME: Chart.yaml
 LOCAL_VOLUME_REPO: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner.git
-LOCAL_VOLUME_CHART_VERSION: 2.5.0
+LOCAL_VOLUME_CHART_VERSION: 2.6.0
 LOCAL_VOLUME_REPO_VERSION: "v{{ LOCAL_VOLUME_CHART_VERSION }}"
 LOCAL_VOLUME_REPO_LOCATION: "/tmp/{{ LOCAL_VOLUME_NAME }}"
 LOCAL_VOLUME_CONFIG:

--- a/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
+++ b/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
@@ -7,7 +7,7 @@ LOCAL_VOLUME_NAME: sig-storage-local-static-provisioner-sas
 LOCAL_VOLUME_NAMESPACE: kube-system
 LOCAL_VOLUME_CHART_NAME: Chart.yaml
 LOCAL_VOLUME_REPO: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner.git
-LOCAL_VOLUME_CHART_VERSION: 2.4.0
+LOCAL_VOLUME_CHART_VERSION: 2.5.0
 LOCAL_VOLUME_REPO_VERSION: "v{{ LOCAL_VOLUME_CHART_VERSION }}"
 LOCAL_VOLUME_REPO_LOCATION: "/tmp/{{ LOCAL_VOLUME_NAME }}"
 LOCAL_VOLUME_CONFIG:

--- a/variables.tf
+++ b/variables.tf
@@ -293,7 +293,7 @@ variable "cluster_domain" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.25.8"
+  default = "1.26.7"
 }
 
 variable "cluster_cni" {


### PR DESCRIPTION
### Changes
 
* Update the default `kubernetes_version` in the example files to 1.26.7. 
* Updated the default `kubectl` version in the Dockerfile to 1.26.7
* Updated `sig-storage-local-static-provisioner` default version to 2.6.0
   *  Versions 2.5.0 and 2.6.0 had no breaking changes or new features that we needed to consider.
   * https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/releases/tag/v2.6.0
   * https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/releases/tag/v2.5.0

### Tests

| Scenario | Provider | kubernetes_version | kubectl version | sig-storage-local-static-provisioner | order  | cadence   | notes             |
|----------|----------|--------------------|-----------------|--------------------------------------|--------|-----------|-------------------|
| 1        | OSS      | 1.26.7             | 1.26.7          | 2.6.0                                | ****** | fast:2020 |                   |
| 2        | OSS      | 1.27.4             | 1.26.7          | 2.6.0                                | n/a    | n/a       | not yet supported |