### PR TITLE
feat: (IAC-1089) Valid PG Server Name and Update Doc

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -289,7 +289,7 @@ postgres_servers = {
 
 **NOTE**: The `default = {}` element is always required when creating external databases. This is the system's default database server.
 
-Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed 
+Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed. When naming the server element, it must follow a valid naming scheme, the name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character.
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
@@ -311,7 +311,9 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
     - The Ansible tasks that are performed include copying the certificate and key from the PostgreSQL VM into your local workspace directory.
 2. If you are planning to use the [viya4-deployment repository](https://github.com/sassoftware/viya4-deployment) to perform a SAS Viya platform deployment where you have [full-stack TLS](https://github.com/sassoftware/viya4-deployment/blob/main/docs/CONFIG-VARS.md#tls) configured, make sure that the `V4_CFG_TLS_TRUSTED_CA_CERTS` variable in the viya4-deployment ansible-vars.yaml file points to a directory that contains the server_ssl_cert_file.
 
-Here is an example of the `postgres_servers` variable where the `default` entry only overrides the `administrator_password` parameter, and the `another-server` entry overrides all parameters:
+Multiple SAS offerings require a second PostgreSQL instance referred to as SAS Common Data Store, or CDS PostgreSQL. For more information, see [Common Customizations](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=dplyml0phy0dkr&docsetTarget=n08u2yg8tdkb4jn18u8zsi6yfv3d.htm#p0wkxxi9s38zbzn19ukjjaxsc0kl). A list of SAS offerings that require CDS PostgreSQL is provided in [SAS Common Data Store Requirements](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=p05lfgkwib3zxbn1t6nyihexp12n.htm#n03wzanutmc6gon1val5fykas9aa). To create and configure an external CDS PostgreSQL instance in addition to the external platform PostgreSQL instance named `default`, specify `cds-postgres` as a second PostgreSQL instance, as shown in the example below.
+
+Here is an example of the `postgres_servers` variable with the `default` server entry overriding only the `administrator_password` parameter and the `cds-postgres` entry overriding all the parameters:
 
 ```terraform
 postgres_servers = {
@@ -319,7 +321,7 @@ postgres_servers = {
     administrator_password       = "D0ntL00kTh1sWay"
     server_ip                    = "10.10.10.10"     # Assigned values for static IPs
   },
-  another_server = {
+  cds-postgres = {
     server_num_cpu         = 8                       # 8 CPUs
     server_memory          = 16384                   # 16 GB
     server_disk_size       = 250                     # 256 GB

--- a/templates/ansible/inventory.tmpl
+++ b/templates/ansible/inventory.tmpl
@@ -92,7 +92,7 @@ cr_server
 %{ for server_name, server_data in postgres_servers ~}
 [${prefix}_${server_name}_pgsql]
 ${server_data.server_ip}
-[${prefix}_${server_name}_pgsql:vars]
+[${prefix}_${server_name}_pgsql:vars | replace("-", "_")]
 postgres_server_name="${server_name}"
 postgres_server_version="${server_data.server_version}"
 postgres_server_ssl="${server_data.server_ssl}"

--- a/templates/ansible/inventory.tmpl
+++ b/templates/ansible/inventory.tmpl
@@ -90,9 +90,9 @@ cr_server
 # Postgres Servers
 #
 %{ for server_name, server_data in postgres_servers ~}
-[${prefix}_${server_name}_pgsql]
+[${prefix}_${replace(server_name, "-", "_")}_pgsql]
 ${server_data.server_ip}
-[${prefix}_${server_name}_pgsql:vars | replace("-", "_")]
+[${prefix}_${replace(server_name, "-", "_")}_pgsql:vars]
 postgres_server_name="${server_name}"
 postgres_server_version="${server_data.server_version}"
 postgres_server_ssl="${server_data.server_ssl}"
@@ -107,7 +107,7 @@ postgres_system_setting_${system_setting.name}="${system_setting.value}"
 %{ endfor ~}
 [postgres:children]
 %{ for server_name, server_data in postgres_servers ~}
-${prefix}_${server_name}_pgsql
+${prefix}_${replace(server_name, "-", "_")}_pgsql
 %{ endfor ~}
 
 %{ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -260,6 +260,10 @@ variable "postgres_servers" {
   description = "Map of PostgreSQL server objects"
   type        = any
   default     = null
+  validation {
+    condition     = var.postgres_servers == null || can([for pg in keys(var.postgres_servers) : regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", pg)])
+    error_message = "ERROR: Postgres Server names must follow a valid naming scheme. Name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+  }
 }
 
 # Regex for validation : ^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$


### PR DESCRIPTION
### Changes

* Added a validation for the names of the postgres servers, so we did not run into failures when the hostname is assigned.
  * Acceptable format: Postgres Server names must follow a valid naming scheme. Name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
* Automatically convert any postgres server names that have a hyphen inside them (e.g. cds-postgres) to be an underscore inside the group headings within the inventory file. The `postgres_server_name` variable inside the inventory file will still have hyphens.
* Updated doc to reflect these changes, and also synced up Postgres doc with other cloud repos.

### Tests

| Scenario | Provider | K8s    | Postgres Servers       | Action                | Order  | Cadence   | Notes                                                       |
|----------|----------|--------|------------------------|-----------------------|--------|-----------|-------------------------------------------------------------|
| 1        | vSphere  | 1.26.7 | default & cds-postgres | apply, setup, install | ****** | fast:2020 | deployment successful, both servers used by Viya deployment |
| 2        | vSphere  | 1.26.7 | default                | apply, setup, install | n/a    | n/a       | default user scenario still works                           |
| 3        | vSphere  | 1.26.7 | null                   | apply, setup, install | n/a    | n/a       | no pg server created, validation error was not thrown       |
| 4        | vSphere  | 1.26.7 | -servername123         | plan                  | n/a    | n/a       | variable validation error thrown                            |
| 5        | vSphere  | 1.26.7 | servername123-         | plan                  | n/a    | n/a       | variable validation error thrown                            |
| 6        | vSphere  | 1.26.7 | server_name123         | plan                  | n/a    | n/a       | variable validation error thrown                            |
| 7        | vSphere  | 1.26.7 | server*name123         | plan                  | n/a    | n/a       | variable validation error thrown                            |
| 8        | vSphere  | 1.26.7 | server-name-123        | plan                  | n/a    | n/a       | validation error was not thrown                             |