### PR TITLE
docs: (IAC-1222) Remove CR Variables from Example Files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,2 @@
+## Complete Container Registry Setup
+- Make updates to the `/systems/container_registry` role to fully set up a Harbor Registry for a user.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -367,13 +367,6 @@ nfs_memory    = 16384        # 16 GB
 nfs_disk_size = 500          # 500 GB
 nfs_ip        = "10.18.0.12" # Assigned values for static IPs
 
-# Container Registry
-create_cr    = false         # Creation flag
-cr_num_cpu   = 4             # 4 CPUs
-cr_memory    = 8092          # 8 GB
-cr_disk_size = 250           # 250 GB
-cr_ip        = "10.18.0.13"  # Assigned values for static IPs
-
 # PostgreSQL server
 #
 #   Suggested server specs shown below.
@@ -633,9 +626,6 @@ jump_ip : ""
 
 # NFS Server
 nfs_ip  : ""
-
-# Container Registry
-cr_ip   : ""
 
 # PostgreSQL Servers
 ```

--- a/examples/bare-metal/sample-ansible-vars.yaml
+++ b/examples/bare-metal/sample-ansible-vars.yaml
@@ -141,6 +141,3 @@ jump_ip : ""
 
 # NFS Server
 nfs_ip  : ""
-
-# Container Registry
-cr_ip   : ""

--- a/examples/bare-metal/sample-inventory
+++ b/examples/bare-metal/sample-inventory
@@ -50,18 +50,6 @@ FIXME - ENTER YOUR NFS SERVER IP/FQDN HERE!
 nfs_server
 
 #
-# Container Registry
-#
-[cr_server]
-FIXME - ENTER YOUR CR SERVER IP/FQDN HERE!
-
-#
-# Container Registry - alias - DO NOT MODIFY
-#
-[cr:children]
-cr_server
-
-#
 # Postgres Servers
 #
 # NOTE: You MUST have an entry for each postgres server

--- a/examples/bare-metal/sample-inventory-internal-postgres
+++ b/examples/bare-metal/sample-inventory-internal-postgres
@@ -54,18 +54,6 @@ FIXME - ENTER YOUR NFS SERVER IP/FQDN HERE!
 nfs_server
 
 #
-# Container Registry
-#
-[cr_server]
-FIXME - ENTER YOUR CR SERVER IP/FQDN HERE!
-
-#
-# Container Registry - alias - DO NOT MODIFY
-#
-[cr:children]
-cr_server
-
-#
 # All systems
 #
 [all:children]

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -189,13 +189,6 @@ nfs_memory    = 16384 # 16 GB
 nfs_disk_size = 500   # 500 GB
 nfs_ip        = ""    # Assigned values for static IPs
 
-# Container Registry
-create_cr    = false # Creation flag
-cr_num_cpu   = 4     # 4 CPUs
-cr_memory    = 8092  # 8 GB
-cr_disk_size = 250   # 250 GB
-cr_ip        = ""    # Assigned values for static IPs
-
 # Postgres Servers
 postgres_servers = {
   default = {

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -151,13 +151,6 @@ nfs_memory    = 16384 # 16 GB
 nfs_disk_size = 500   # 500 GB
 nfs_ip        = ""    # Assigned values for static IPs
 
-# Container Registry
-create_cr    = false # Creation flag
-cr_num_cpu   = 4     # 4 CPUs
-cr_memory    = 8092  # 8 GB
-cr_disk_size = 250   # 250 GB
-cr_ip        = ""    # Assigned values for static IPs
-
 # Postgres Servers
 postgres_servers = {
   default = {

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -190,13 +190,6 @@ nfs_memory    = 16384 # 16 GB
 nfs_disk_size = 500   # 500 GB
 nfs_ip        = ""    # Assigned values for static IPs
 
-# Container Registry
-create_cr    = true # Creation flag
-cr_num_cpu   = 4    # 4 CPUs
-cr_memory    = 8092 # 8 GB
-cr_disk_size = 250  # 250 GB
-cr_ip        = ""   # Assigned values for static IPs
-
 # Postgres Servers
 postgres_servers = {
   default = {

--- a/examples/vsphere/sample-terraform-static-singlestore.tfvars
+++ b/examples/vsphere/sample-terraform-static-singlestore.tfvars
@@ -216,13 +216,6 @@ nfs_memory    = 16384 # 16 GB
 nfs_disk_size = 500   # 500 GB
 nfs_ip        = ""    # Assigned values for static IPs
 
-# Container Registry
-create_cr    = false # Creation flag
-cr_num_cpu   = 4     # 4 CPUs
-cr_memory    = 8092  # 8 GB
-cr_disk_size = 250   # 250 GB
-cr_ip        = ""    # Assigned values for static IPs
-
 # Postgres Servers
 postgres_servers = {
   default = {

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -143,13 +143,6 @@ nfs_memory    = 16384 # 16 GB
 nfs_disk_size = 500   # 500 GB
 nfs_ip        = ""    # Assigned values for static IPs
 
-# Container Registry
-create_cr    = false # Creation flag
-cr_num_cpu   = 4     # 4 CPUs
-cr_memory    = 8092  # 8 GB
-cr_disk_size = 250   # 250 GB
-cr_ip        = ""    # Assigned values for static IPs
-
 # Postgres Servers
 postgres_servers = {
   default = {

--- a/variables.tf
+++ b/variables.tf
@@ -212,7 +212,7 @@ variable "nfs_disk_size" {
   default = 250
 }
 
-# container registry - WIP
+# container registry - TODO
 variable "create_cr" {
   type    = bool
   default = false

--- a/variables.tf
+++ b/variables.tf
@@ -212,7 +212,7 @@ variable "nfs_disk_size" {
   default = 250
 }
 
-# container registry
+# container registry - WIP
 variable "create_cr" {
   type    = bool
   default = false


### PR DESCRIPTION
### Changes

Remove CR variable from example file and add a TODO file. 
The CR setup ansible roles does not fully setup up a Harbor registry, removing it from doc until it's complete.