### PR TITLE
fix: (IAC-1246) remove unused var `cluster_node_pool_mode` from example & output

### DIFF
--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -83,7 +83,6 @@ control_plane_ssh_key_name = "cp_ssh"
 #                     These are typically: compute, stateful, and
 #                     stateless. 
 #
-cluster_node_pool_mode = "minimal"
 node_pools = {
   # REQUIRED NODE TYPE - DO NOT REMOVE and DO NOT CHANGE THE NAME
   #                      Other variables may be altered

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,10 +5,6 @@ output "cluster_name" {
   value = local.cluster_name
 }
 
-output "cluster_node_pool_mode" {
-  value = "default"
-}
-
 output "jump_admin_username" {
   value = "root"
 }


### PR DESCRIPTION
### Changes

Removes the unused variable `cluster_node_pool_mode` from example file & output

### Tests

| Scenario | Provider | K8s Version | Notes                                              |
|----------|----------|-------------|----------------------------------------------------|
| 1        | OSS      | 1.26.7      | cluster_node_pool_mode no longer present in output |
