### PR TITLE
fix: (IAC-1247) Add OS Guardrail to containerd.io Task

### DIFF
--- a/roles/kubernetes/cri/containerd/tasks/main.yaml
+++ b/roles/kubernetes/cri/containerd/tasks/main.yaml
@@ -105,7 +105,9 @@
 - name: Set containerd.io package debian revision if not specified
   set_fact:
     kubernetes_cri_deb_rev: "-*"
-  when: kubernetes_cri_version | regex_search("^(\d+\.)(\d+\.)(\d+)$")
+  when:
+    - ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")
+    - kubernetes_cri_version | regex_search("^(\d+\.)(\d+\.)(\d+)$")
   tags:
     - install
     - update


### PR DESCRIPTION
### Changes
Add conditional to gate the `Set containerd.io package debian revision if not specified` task by OS

### Tests
| Scenario | Provider | K8s Version | OS                 | kubernetes_cri_version | Notes                                   |
|----------|----------|-------------|--------------------|------------------------|-----------------------------------------|
| 1        | OSS      | 1.26.7      | Ubuntu 22.04.3 LTS | unset, default value   |                                         |
| 2        | OSS      | 1.26.7      | Ubuntu 22.04.3 LTS | "1.6.20-1"             | task skipped since we specified deb rev |
| 3        | OSS      | 1.26.7      | Ubuntu 20.04.6 LTS | unset, default value   |                                         |
| 4        | OSS      | 1.26.7      | Ubuntu 20.04.6 LTS | "1.6.20-1"             | task skipped since we specified deb rev |
