### PR TITLE
feat: (IAC-1187) Update METRICS_SERVER_CHART_VERSION default to 3.11.0

### DIFF
--- a/roles/kubernetes/metrics/metrics-server/defaults/main.yaml
+++ b/roles/kubernetes/metrics/metrics-server/defaults/main.yaml
@@ -7,7 +7,7 @@ METRICS_SERVER_NAME: metrics-server
 METRICS_SERVER_NAMESPACE: kube-system
 METRICS_SERVER_CHART_NAME: metrics-server
 METRICS_SERVER_CHART_URL: https://kubernetes-sigs.github.io/metrics-server/
-METRICS_SERVER_CHART_VERSION: 3.8.3
+METRICS_SERVER_CHART_VERSION: 3.11.0
 METRICS_SERVER_CONFIG:
   apiService:
     create: true


### PR DESCRIPTION
### Changes

Update the default `METRICS_SERVER_CHART_VERSION` default to 3.11.0 to pull in fixes and improvements. This version is compatible with K8s 1.19+
https://github.com/kubernetes-sigs/metrics-server?tab=readme-ov-file#compatibility-matrix

### Tests

| Scenario | Provider | kubectl version | cluster_version | cluster_cni | cluster_cni_version | cluster_cri | cluster_cri_version | METRICS_SERVER_CHART_VERSION | Order  | Cadence   |
|----------|----------|-----------------|-----------------|-------------|---------------------|-------------|---------------------|------------------------------|--------|-----------|
| 1        | OSS      | 1.27.9          | 1.26.12         | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 |
| 2        | OSS      | 1.27.9          | 1.27.9          | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 |
| 3        | OSS      | 1.27.9          | 1.28.5          | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 | 