### PR TITLE
feat: (IAC-1189) Add Support for K8s 1.28 and Update Default CRI Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 # Layers used for building/downloading/installing tools
 FROM baseline as tool_builder
 ARG HELM_VERSION=3.13.2
-ARG KUBECTL_VERSION=1.26.10
+ARG KUBECTL_VERSION=1.27.9
 ARG TERRAFORM_VERSION=1.6.3-*
 
 WORKDIR /build

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -69,11 +69,11 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| cluster_version        | Kubernetes version | string | "1.26.7" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
+| cluster_version        | Kubernetes version | string | "1.27.9" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
 | cluster_cni            | Kubernetes container network interface (CNI) | string | "calico" | |
 | cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.24.5" | |
 | cluster_cri            | Kubernetes container runtime interface (CRI) | string | "containerd" | |
-| cluster_cri_version    | Version of the CRI specifed by `cluster_cri` to be installed  | string | "1.6.20" | Set as an empty string to use the latest upstream version from the Docker APT repository. Currently only containerd is supported, see the [releases page](https://github.com/containerd/containerd/releases) for available versions |
+| cluster_cri_version    | Version of the CRI specifed by `cluster_cri` to be installed  | string | "1.6.26" | Set as an empty string to use the latest upstream version from the Docker APT repository. Currently only containerd is supported, see the [releases page](https://github.com/containerd/containerd/releases) for available versions |
 | cluster_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |
 | cluster_pod_subnet     | Kubernetes pod subnet | string | "10.42.0.0/16" | |
 | cluster_domain         | Cluster domain suffix for DNS | string | | |
@@ -353,13 +353,13 @@ The following variables are used to describe the machine targets for the SAS Viy
 | prefix | A prefix used in the names of all the resources created by this script | string | | |
 | deployment_type | Type of deployment to be performed | string | "bare_metal" | Specify `bare_metal` or `vsphere`. |
 | kubernetes_cluster_name | Cluster name | string | "{{ prefix }}-oss" | This item is auto-filled. **ONLY** change the `prefix` value described previously. |
-| kubernetes_version | Kubernetes version | string | "1.26.7" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
+| kubernetes_version | Kubernetes version | string | "1.27.9" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
 | kubernetes_upgrade_allowed | | bool | true | **NOTE:** Not currently used. |
 | kubernetes_arch | | string | "{{ vm_arch }}" | This item is auto-filled. **ONLY** change the `vm_arch` value described previously. |
 | kubernetes_cni | Kubernetes Container Network Interface (CNI) | string | "calico" | |
 | kubernetes_cni_version | Kubernetes Container Network Interface (CNI) Version | string | "3.24.5" | |
 | kubernetes_cri | Kubernetes Container Runtime Interface (CRI) | string | "containerd" | |
-| kubernetes_cri_version | Version of the CRI specifed by `kubernetes_cri` to be installed  | string | "1.6.20" | Set as an empty string to use the latest upstream version from the Docker APT repository. Currently only containerd is supported, see the [releases page](https://github.com/containerd/containerd/releases) for available versions | |
+| kubernetes_cri_version | Version of the CRI specifed by `kubernetes_cri` to be installed  | string | "1.6.26" | Set as an empty string to use the latest upstream version from the Docker APT repository. Currently only containerd is supported, see the [releases page](https://github.com/containerd/containerd/releases) for available versions | |
 | kubernetes_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |
 | kubernetes_pod_subnet | Kubernetes pod subnet | string | "10.42.0.0/16" | |
 | kubernetes_vip_version | kube-vip version | string | "0.5.7" | |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -203,11 +203,11 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh" # Directory holding public keys to be used on each machine
 
 # Kubernetes - Cluster
-cluster_version        = "1.26.7"                        # Kubernetes version
+cluster_version        = "1.27.9"                        # Kubernetes version
 cluster_cni            = "calico"                        # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"                        # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"                    # Kubernetes Container Runtime Interface (CRI)
-cluster_cri_version    = "1.6.20"                        # Kubernetes Container Runtime Interface (CRI) Version
+cluster_cri_version    = "1.6.26"                        # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.35.0.0/16"                  # Kubernetes service subnet
 cluster_pod_subnet     = "10.36.0.0/16"                  # Kubernetes Pod subnet
 cluster_domain         = "sample.domain.foo.com"         # Cluster domain suffix for DNS
@@ -512,7 +512,7 @@ kubernetes_arch            : "{{ vm_arch }}"
 kubernetes_cni             : "calico"           # Choices : [calico]
 kubernetes_cni_version     : "3.24.5"           # Choices : [3.24.5]
 kubernetes_cri             : "containerd"       # Choices : [containerd]
-kubernetes_cri_version     : "1.6.20"           # Choices : [1.6.20]
+kubernetes_cri_version     : "1.6.26"           # Choices : [1.6.26]
 kubernetes_service_subnet  : ""
 kubernetes_pod_subnet      : ""
 

--- a/examples/bare-metal/sample-ansible-vars.yaml
+++ b/examples/bare-metal/sample-ansible-vars.yaml
@@ -26,7 +26,7 @@ kubernetes_arch            : "{{ vm_arch }}"
 kubernetes_cni             : "calico"        # Choices : [calico]
 kubernetes_cni_version     : "3.24.5"        # Choices : [3.24.5]
 kubernetes_cri             : "containerd"    # Choices : [containerd]
-kubernetes_cri_version     : "1.6.20"        # Choices : [1.6.20]
+kubernetes_cri_version     : "1.6.26"        # Choices : [1.6.26]
 kubernetes_service_subnet  : ""
 kubernetes_pod_subnet      : ""
 

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -18,11 +18,11 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.26.7"       # Kubernetes Version
+cluster_version        = "1.27.9"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
-cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
+cluster_cri_version    = "1.6.26"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
 cluster_pod_subnet     = "10.42.0.0/16" # Kubernetes Pod Subnet
 cluster_domain         = ""             # Cluster domain suffix for DNS

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -18,11 +18,11 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.26.7"       # Kubernetes Version
+cluster_version        = "1.27.9"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
-cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
+cluster_cri_version    = "1.6.26"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
 cluster_pod_subnet     = "10.42.0.0/16" # Kubernetes Pod Subnet
 cluster_domain         = ""             # Cluster domain suffix for DNS

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -18,11 +18,11 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.26.7"       # Kubernetes Version
+cluster_version        = "1.27.9"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
-cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
+cluster_cri_version    = "1.6.26"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
 cluster_pod_subnet     = "10.42.0.0/16" # Kubernetes Pod Subnet
 cluster_domain         = ""             # Cluster domain suffix for DNS

--- a/examples/vsphere/sample-terraform-static-singlestore.tfvars
+++ b/examples/vsphere/sample-terraform-static-singlestore.tfvars
@@ -18,11 +18,11 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.26.7"       # Kubernetes Version
+cluster_version        = "1.27.9"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
-cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
+cluster_cri_version    = "1.6.26"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
 cluster_pod_subnet     = "10.42.0.0/16" # Kubernetes Pod Subnet
 cluster_domain         = ""             # Cluster domain suffix for DNS

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -18,11 +18,11 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.26.7"       # Kubernetes Version
+cluster_version        = "1.27.9"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
-cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
+cluster_cri_version    = "1.6.26"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet
 cluster_pod_subnet     = "10.42.0.0/16" # Kubernetes Pod Subnet
 cluster_domain         = ""             # Cluster domain suffix for DNS

--- a/roles/kubernetes/cri/containerd/defaults/main.yaml
+++ b/roles/kubernetes/cri/containerd/defaults/main.yaml
@@ -11,5 +11,5 @@
 # Focal 20 https://download.docker.com/linux/ubuntu/dists/focal/stable/binary-amd64/
 # On that page select "Packages" and the text file that is downloaded will contain all the versions of
 # containerd available in the repository.
-kubernetes_cri_version: "1.6.20"
+kubernetes_cri_version: "1.6.26"
 kubernetes_cri_deb_rev: ""

--- a/roles/kubernetes/toolbox/defaults/main.yaml
+++ b/roles/kubernetes/toolbox/defaults/main.yaml
@@ -1,0 +1,10 @@
+# Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Allows users to overwrite deb revisions of the kube toolbox packages
+# kubelet, kubeadm, & kubectl which will be installed on all the
+# ansible "k8s" hosts.
+# It's not recommended you change this value unless for debugging purposes.
+# leaving it as am empty string will result in the latest deb rev for the packages
+kube_deb_rev: ""

--- a/roles/kubernetes/toolbox/defaults/main.yaml
+++ b/roles/kubernetes/toolbox/defaults/main.yaml
@@ -6,5 +6,5 @@
 # kubelet, kubeadm, & kubectl which will be installed on all the
 # ansible "k8s" hosts.
 # It's not recommended you change this value unless for debugging purposes.
-# leaving it as am empty string will result in the latest deb rev for the packages
-kube_deb_rev: ""
+# leaving it as this default value will result in the latest deb rev for the packages
+kube_deb_rev: "-*"

--- a/roles/kubernetes/toolbox/defaults/main.yaml
+++ b/roles/kubernetes/toolbox/defaults/main.yaml
@@ -7,4 +7,4 @@
 # ansible "k8s" hosts.
 # It's not recommended you change this value unless for debugging purposes.
 # leaving it as this default value will result in the latest deb rev for the packages
-kube_deb_rev: "-*"
+kube_deb_rev: "*"

--- a/roles/kubernetes/toolbox/tasks/main.yaml
+++ b/roles/kubernetes/toolbox/tasks/main.yaml
@@ -46,11 +46,11 @@
     - update
 
 # Add Kubernetes apt repository
-- name: add Kubernetes apt repository
+- name: Add Kubernetes apt repository
   ansible.builtin.apt_repository:
     repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v{{ k8s_major_version }}.{{ k8s_minor_version }}/deb/ /"
     state: present
-    update_cache: yes
+    update_cache: true
   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")
   tags:
     - install
@@ -119,9 +119,9 @@
 - name: Update apt package index and install kubelet, kubeadm, kubectl
   ansible.builtin.apt:
     pkg:
-      - kubelet={{ kubernetes_version }}-{{kube_deb_rev}}
-      - kubeadm={{ kubernetes_version }}-{{kube_deb_rev}}
-      - kubectl={{ kubernetes_version }}-{{kube_deb_rev}}
+      - kubelet={{ kubernetes_version }}-{{ kube_deb_rev }}
+      - kubeadm={{ kubernetes_version }}-{{ kube_deb_rev }}
+      - kubectl={{ kubernetes_version }}-{{ kube_deb_rev }}
     state: present
     update_cache: true
   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")
@@ -156,9 +156,9 @@
 - name: Update apt package index and remove kubelet, kubeadm, kubectl
   ansible.builtin.apt:
     pkg:
-      - kubelet={{ kubernetes_version }}-{{kube_deb_rev}}
-      - kubeadm={{ kubernetes_version }}-{{kube_deb_rev}}
-      - kubectl={{ kubernetes_version }}-{{kube_deb_rev}}
+      - kubelet={{ kubernetes_version }}-{{ kube_deb_rev }}
+      - kubeadm={{ kubernetes_version }}-{{ kube_deb_rev }}
+      - kubectl={{ kubernetes_version }}-{{ kube_deb_rev }}
     state: absent
     update_cache: true
   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")

--- a/roles/kubernetes/toolbox/tasks/main.yaml
+++ b/roles/kubernetes/toolbox/tasks/main.yaml
@@ -6,41 +6,52 @@
 # Installing Kubernetes tooling
 #
 
-# Apply Google Cloud public signing key
-- name: Apply Google Cloud public signing key
+# Only applicable for releases older than Ubuntu 22.04
+- name: Create /etc/apt/keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04")
+  tags:
+    - install
+    - update
+
+- name: Set kubernetes version facts for toolbox installation
+  set_fact:
+    k8s_version_semantic_parts: "{{ kubernetes_version.split('.') }}"
+  tags:
+    - install
+    - update
+
+- name: Set kubernetes version part facts for toolbox installation
+  set_fact:
+    k8s_major_version: "{% if k8s_version_semantic_parts|length > 0 %}{{ k8s_version_semantic_parts.0 }}{% endif %}"
+    k8s_minor_version: "{% if k8s_version_semantic_parts|length > 1 %}{{ k8s_version_semantic_parts.1 }}{% endif %}"
+    k8s_patch_version: "{% if k8s_version_semantic_parts|length > 2 %}{{ k8s_version_semantic_parts.2 }}{% else %}0{% endif %}"
+  tags:
+    - install
+    - update
+
+# Apply Kubernetes public signing key
+- name: Apply Kubernetes public signing key
   ansible.builtin.get_url:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-    dest: /usr/share/keyrings/kubernetes-archive-keyring.gpg
+    url: "https://pkgs.k8s.io/core:/stable:/v{{ k8s_major_version }}.{{ k8s_minor_version }}/deb/Release.key"
+    dest: /etc/apt/keyrings/kubernetes-apt-keyring.asc
   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
 
 # Add Kubernetes apt repository
-- name: Add Kubernetes apt repository
-  ansible.builtin.copy:
-    dest: /etc/apt/sources.list.d/kubernetes.list
-    content: |
-      deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg trusted=yes] https://apt.kubernetes.io/ kubernetes-xenial main
+- name: add Kubernetes apt repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v{{ k8s_major_version }}.{{ k8s_minor_version }}/deb/ /"
+    state: present
+    update_cache: yes
   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")
-  tags:
-    - install
-    - update
-
-- name: Set kubernetes version facts for crictl
-  set_fact:
-    k8s_version_semantic_parts: "{{ kubernetes_version.split('.') }}"
-  when: kubernetes_cri|lower != 'docker'
-  tags:
-    - install
-    - update
-
-- name: Set kubernetes version part facts for crictl
-  set_fact:
-    k8s_major_version: "{% if k8s_version_semantic_parts|length > 0 %}{{ k8s_version_semantic_parts.0 }}{% endif %}"
-    k8s_minor_version: "{% if k8s_version_semantic_parts|length > 1 %}{{ k8s_version_semantic_parts.1 }}{% endif %}"
-    k8s_patch_version: "{% if k8s_version_semantic_parts|length > 2 %}{{ k8s_version_semantic_parts.2 }}{% else %}0{% endif %}"
-  when: kubernetes_cri|lower != 'docker'
   tags:
     - install
     - update
@@ -108,9 +119,9 @@
 - name: Update apt package index and install kubelet, kubeadm, kubectl
   ansible.builtin.apt:
     pkg:
-      - kubelet={{ kubernetes_version }}-00
-      - kubeadm={{ kubernetes_version }}-00
-      - kubectl={{ kubernetes_version }}-00
+      - kubelet={{ kubernetes_version }}-{{kube_deb_rev}}
+      - kubeadm={{ kubernetes_version }}-{{kube_deb_rev}}
+      - kubectl={{ kubernetes_version }}-{{kube_deb_rev}}
     state: present
     update_cache: true
   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")
@@ -145,9 +156,9 @@
 - name: Update apt package index and remove kubelet, kubeadm, kubectl
   ansible.builtin.apt:
     pkg:
-      - kubelet={{ kubernetes_version }}-00
-      - kubeadm={{ kubernetes_version }}-00
-      - kubectl={{ kubernetes_version }}-00
+      - kubelet={{ kubernetes_version }}-{{kube_deb_rev}}
+      - kubeadm={{ kubernetes_version }}-{{kube_deb_rev}}
+      - kubectl={{ kubernetes_version }}-{{kube_deb_rev}}
     state: absent
     update_cache: true
   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "20.04" or ansible_distribution_version == "22.04")

--- a/variables.tf
+++ b/variables.tf
@@ -297,7 +297,7 @@ variable "cluster_domain" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.26.7"
+  default = "1.27.9"
 }
 
 variable "cluster_cni" {
@@ -317,7 +317,7 @@ variable "cluster_cri" {
 
 variable "cluster_cri_version" {
   type    = string
-  default = "1.6.20"
+  default = "1.6.26"
 }
 
 variable "cluster_service_subnet" {


### PR DESCRIPTION
### Changes

Updates the default `kubelet`, `kubectl`, and `kubeadm` versions to 1.27.9. The version of `containerd` was also updated to 1.6.26 to pull in fixes and improvements, this version is still compatible with K8s 1.24+
https://containerd.io/releases/#kubernetes-support

### Release Notes
This note will be included in the release notes:

Updated the package repo we source the `kube` packages to now be `pkgs.k8s.io` It's important to note that this new package repo will only distribute binaries for K8s 1.24 and onwards.

From: https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/

> The legacy package repositories (apt.kubernetes.io and yum.kubernetes.io) have been deprecated and frozen starting from September 13, 2023. Using the new package repositories hosted at pkgs.k8s.io is strongly recommended and required in order to install Kubernetes versions released after September 13, 2023. The deprecated legacy repositories, and their contents, might be removed at any time in the future and without a further notice period. The new package repositories provide downloads for Kubernetes versions starting with v1.24.0.<br>
...<br>
The legacy packages are expected to go away in January 2024.

### Tests

| Scenario | Provider | kubectl version | cluster_version | cluster_cni | cluster_cni_version | cluster_cri | cluster_cri_version | METRICS_SERVER_CHART_VERSION | Order  | Cadence   |
|----------|----------|-----------------|-----------------|-------------|---------------------|-------------|---------------------|------------------------------|--------|-----------|
| 1        | OSS      | 1.27.9          | 1.26.12         | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 |
| 2        | OSS      | 1.27.9          | 1.27.9          | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 |
| 3        | OSS      | 1.27.9          | 1.28.5          | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 | 