### PR TITLE
feat: (IAC-1225) Update default Calico CNI Version to 3.27.0

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -71,7 +71,7 @@ Terraform input variables can be set in the following ways:
 | :--- | :--- | :--- | :--- | :--- |
 | cluster_version        | Kubernetes version | string | "1.26.7" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
 | cluster_cni            | Kubernetes container network interface (CNI) | string | "calico" | |
-| cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.24.5" | |
+| cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.27.0" | |
 | cluster_cri            | Kubernetes container runtime interface (CRI) | string | "containerd" | |
 | cluster_cri_version    | Version of the CRI specifed by `cluster_cri` to be installed  | string | "1.6.20" | Set as an empty string to use the latest upstream version from the Docker APT repository. Currently only containerd is supported, see the [releases page](https://github.com/containerd/containerd/releases) for available versions |
 | cluster_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |
@@ -357,7 +357,7 @@ The following variables are used to describe the machine targets for the SAS Viy
 | kubernetes_upgrade_allowed | | bool | true | **NOTE:** Not currently used. |
 | kubernetes_arch | | string | "{{ vm_arch }}" | This item is auto-filled. **ONLY** change the `vm_arch` value described previously. |
 | kubernetes_cni | Kubernetes Container Network Interface (CNI) | string | "calico" | |
-| kubernetes_cni_version | Kubernetes Container Network Interface (CNI) Version | string | "3.24.5" | |
+| kubernetes_cni_version | Kubernetes Container Network Interface (CNI) Version | string | "3.27.0" | |
 | kubernetes_cri | Kubernetes Container Runtime Interface (CRI) | string | "containerd" | |
 | kubernetes_cri_version | Version of the CRI specifed by `kubernetes_cri` to be installed  | string | "1.6.20" | Set as an empty string to use the latest upstream version from the Docker APT repository. Currently only containerd is supported, see the [releases page](https://github.com/containerd/containerd/releases) for available versions | |
 | kubernetes_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -205,7 +205,7 @@ system_ssh_keys_dir = "~/.ssh" # Directory holding public keys to be used on eac
 # Kubernetes - Cluster
 cluster_version        = "1.26.7"                        # Kubernetes version
 cluster_cni            = "calico"                        # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.24.5"                        # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.27.0"                        # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"                    # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.20"                        # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.35.0.0/16"                  # Kubernetes service subnet
@@ -510,7 +510,7 @@ kubernetes_version         : ""
 kubernetes_upgrade_allowed : true
 kubernetes_arch            : "{{ vm_arch }}"
 kubernetes_cni             : "calico"           # Choices : [calico]
-kubernetes_cni_version     : "3.24.5"           # Choices : [3.24.5]
+kubernetes_cni_version     : "3.27.0"           # Choices : [3.27.0]
 kubernetes_cri             : "containerd"       # Choices : [containerd]
 kubernetes_cri_version     : "1.6.20"           # Choices : [1.6.20]
 kubernetes_service_subnet  : ""

--- a/examples/bare-metal/sample-ansible-vars.yaml
+++ b/examples/bare-metal/sample-ansible-vars.yaml
@@ -24,7 +24,7 @@ kubernetes_version         : ""
 kubernetes_upgrade_allowed : true
 kubernetes_arch            : "{{ vm_arch }}"
 kubernetes_cni             : "calico"        # Choices : [calico]
-kubernetes_cni_version     : "3.24.5"        # Choices : [3.24.5]
+kubernetes_cni_version     : "3.27.0"        # Choices : [3.27.0]
 kubernetes_cri             : "containerd"    # Choices : [containerd]
 kubernetes_cri_version     : "1.6.20"        # Choices : [1.6.20]
 kubernetes_service_subnet  : ""

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -20,7 +20,7 @@ system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on
 # Kubernetes - Cluster
 cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.27.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -20,7 +20,7 @@ system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on
 # Kubernetes - Cluster
 cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.27.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -20,7 +20,7 @@ system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on
 # Kubernetes - Cluster
 cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.27.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-static-singlestore.tfvars
+++ b/examples/vsphere/sample-terraform-static-singlestore.tfvars
@@ -20,7 +20,7 @@ system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on
 # Kubernetes - Cluster
 cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.27.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -20,7 +20,7 @@ system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on
 # Kubernetes - Cluster
 cluster_version        = "1.26.7"       # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.24.5"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.27.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.20"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/roles/kubernetes/cni/calico/templates/custom-resources.tmpl
+++ b/roles/kubernetes/cni/calico/templates/custom-resources.tmpl
@@ -1,6 +1,6 @@
 ---
 # This section includes base Calico installation configuration.
-# For more information, see: https://projectcalico.docs.tigera.io/reference/installation/api#operator.tigera.io/v1.Installation
+# For more information, see: https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Installation
 apiVersion: operator.tigera.io/v1
 kind: Installation
 metadata:
@@ -17,7 +17,7 @@ spec:
       nodeSelector: all()
 ---
 # This section configures the Calico API server.
-# For more information, see: https://projectcalico.docs.tigera.io/reference/installation/api#operator.tigera.io/v1.APIServer
+# For more information, see: https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.APIServer
 apiVersion: operator.tigera.io/v1
 kind: APIServer 
 metadata: 

--- a/variables.tf
+++ b/variables.tf
@@ -307,7 +307,7 @@ variable "cluster_cni" {
 
 variable "cluster_cni_version" {
   type    = string
-  default = "3.24.5"
+  default = "3.27.0"
 }
 
 variable "cluster_cri" {


### PR DESCRIPTION
### Changes

Update the default Calico CNI version to 3.27.0 (`cluster_cni_version` & `kubernetes_cni_version`) to pull in the latest fixes and improvements.

This new version was tested by Tigera to work against K8s 1.24-1.28 so we are bumping the version
https://docs.tigera.io/calico/3.27/getting-started/kubernetes/requirements#kubernetes-requirements

### Tests

| Scenario | Provider | kubectl version | cluster_version | cluster_cni | cluster_cni_version | cluster_cri | cluster_cri_version | METRICS_SERVER_CHART_VERSION | Order  | Cadence   |
|----------|----------|-----------------|-----------------|-------------|---------------------|-------------|---------------------|------------------------------|--------|-----------|
| 1        | OSS      | 1.27.9          | 1.26.12         | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 |
| 2        | OSS      | 1.27.9          | 1.27.9          | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 |
| 3        | OSS      | 1.27.9          | 1.28.5          | calico      | 3.27.0              | containerd  | 1.6.26              | 3.11.0                       | * | fast:2020 | 