### PR TITLE
feat: (IAC-1313) Use the `~>` Notation for Provider Version Constraints

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,11 +6,11 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = "2.6.1"
+      version = "~> 2.6"
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.4.1"
+      version = "~> 2.4"
     }
   }
 }


### PR DESCRIPTION
### Changes

In order to line up with the same Terraform provider/modules versioning standards as the other IAC projects `versions.tf` was updated to use the `~>` notation.

### Tests

| Scenario | Provider | K8s Version | Order  | Cadence   |
|----------|----------|-------------|--------|-----------|
| 1        | OSS      | v1.28.6     | ****** | fast:2020 |  
| 2        | OSS      | v1.26.13    | ****** | fast:2020 | 
