### PR TITLE
feat: (IAC-1269) Update K8s node reboot task to not run on non-k8s node VMs

### DIFF
--- a/roles/kubernetes/common/tasks/main.yaml
+++ b/roles/kubernetes/common/tasks/main.yaml
@@ -175,3 +175,5 @@
   ansible.builtin.reboot:
   tags:
     - install
+  when: inventory_hostname in groups["k8s"]
+

--- a/roles/kubernetes/common/tasks/main.yaml
+++ b/roles/kubernetes/common/tasks/main.yaml
@@ -176,4 +176,3 @@
   tags:
     - install
   when: inventory_hostname in groups["k8s"]
-


### PR DESCRIPTION
### Changes

Only reboot the K8s nodes in `/roles/kubernetes/common/defaults/main.yaml`. Allow other nodes to stay online, allows users who run the IAC code from Jump from having their executions interrupted.

### Tests

| Scenario | Provider | K8s Version | Order  | Cadence   | Notes                 |
|----------|----------|-------------|--------|-----------|-----------------------|
| 1        | OSS      | v1.28.6     | ****** | fast:2020 | only K8s nodes reboot |  

