### PR TITLE
feat: (IAC-1379) Add Support for K8s 1.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 # Layers used for building/downloading/installing tools
 FROM baseline as tool_builder
 ARG HELM_VERSION=3.14.2
-ARG KUBECTL_VERSION=1.27.11
+ARG KUBECTL_VERSION=1.28.7
 ARG TERRAFORM_VERSION=1.7.4-*
 
 WORKDIR /build

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -69,7 +69,7 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| cluster_version        | Kubernetes version | string | "1.27.11" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
+| cluster_version        | Kubernetes version | string | "1.28.7" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
 | cluster_cni            | Kubernetes container network interface (CNI) | string | "calico" | |
 | cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.27.2" | |
 | cluster_cri            | Kubernetes container runtime interface (CRI) | string | "containerd" | |
@@ -353,7 +353,7 @@ The following variables are used to describe the machine targets for the SAS Viy
 | prefix | A prefix used in the names of all the resources created by this script | string | | |
 | deployment_type | Type of deployment to be performed | string | "bare_metal" | Specify `bare_metal` or `vsphere`. |
 | kubernetes_cluster_name | Cluster name | string | "{{ prefix }}-oss" | This item is auto-filled. **ONLY** change the `prefix` value described previously. |
-| kubernetes_version | Kubernetes version | string | "1.27.11" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
+| kubernetes_version | Kubernetes version | string | "1.28.7" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
 | kubernetes_upgrade_allowed | | bool | true | **NOTE:** Not currently used. |
 | kubernetes_arch | | string | "{{ vm_arch }}" | This item is auto-filled. **ONLY** change the `vm_arch` value described previously. |
 | kubernetes_cni | Kubernetes Container Network Interface (CNI) | string | "calico" | |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -203,7 +203,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh" # Directory holding public keys to be used on each machine
 
 # Kubernetes - Cluster
-cluster_version        = "1.27.11"                       # Kubernetes version
+cluster_version        = "1.28.7"                       # Kubernetes version
 cluster_cni            = "calico"                        # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.27.2"                        # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"                    # Kubernetes Container Runtime Interface (CRI)

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -53,7 +53,7 @@ Example of using build arguments to control specific versions of dependencies in
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg KUBECTL_VERSION=1.27.11 \
+	--build-arg KUBECTL_VERSION=1.28.7 \
 	-t viya4-iac-k8s .
 ```
 

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.27.11"      # Kubernetes Version
+cluster_version        = "1.28.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.27.11"      # Kubernetes Version
+cluster_version        = "1.28.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.27.11"      # Kubernetes Version
+cluster_version        = "1.28.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-static-singlestore.tfvars
+++ b/examples/vsphere/sample-terraform-static-singlestore.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.27.11"      # Kubernetes Version
+cluster_version        = "1.28.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -18,7 +18,7 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.27.11"      # Kubernetes Version
+cluster_version        = "1.28.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
 cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)

--- a/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
+++ b/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
@@ -15,8 +15,10 @@
 
 # TODO ADD DOC, workaround for https://github.com/kube-vip/kube-vip/issues/684
 - name: Update kube-vip.yaml to use super-admin.conf for kubeadm init in 1.29+
-  ansible.builtin.shell: >
-    sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml
+  ansible.builtin.replace:
+    path: /etc/kubernetes/manifests/kube-vip.yaml
+    regexp: "path: /etc/kubernetes/admin.conf"
+    replace: "path: /etc/kubernetes/super-admin.conf"
   when: kubernetes_version is version("1.29.0", "ge", version_type="semver")
   tags:
     - install
@@ -30,8 +32,10 @@
 
 # TODO ADD DOC, workaround for https://github.com/kube-vip/kube-vip/issues/684
 - name: Restore kube-vip.yaml to use admin.conf for kubeadm init in 1.29+
-  ansible.builtin.shell: >
-    sed -i 's#path: /etc/kubernetes/super-admin.conf#path: /etc/kubernetes/admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml
+  ansible.builtin.replace:
+    path: /etc/kubernetes/manifests/kube-vip.yaml
+    regexp: "path: /etc/kubernetes/super-admin.conf"
+    replace: "path: /etc/kubernetes/admin.conf"
   when: kubernetes_version is version("1.29.0", "ge", version_type="semver")
   tags:
     - install

--- a/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
+++ b/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
@@ -19,7 +19,7 @@
     - install
     - update
   when:
-    kubernetes_version is version('1.29.0', 'ge', version_type='semver')"
+    kubernetes_version is version("1.29.0", "ge", version_type="semver")
   block:
     - name: Back up admin.conf
       ansible.builtin.copy:

--- a/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
+++ b/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
@@ -13,11 +13,44 @@
     - install
     - update
 
+# TODO ADD DOC, workaround for https://github.com/kube-vip/kube-vip/issues/684
+- name: Update admin.conf for K8s 1.29+
+  tags:
+    - install
+    - update
+  block:
+    - name: Back up admin.conf
+      ansible.builtin.copy:
+        src: "/etc/kubernetes/admin.conf"
+        dest: "/etc/kubernetes/admin.conf.bak"
+      tags:
+        - install
+        - update
+    - name: Replace admin with super.conf
+      ansible.builtin.copy:
+        src: "/etc/kubernetes/super-admin.conf"
+        dest: "/etc/kubernetes/admin.conf"
+      tags:
+        - install
+        - update
+  when:
+     kubernetes_version is version('1.29.0', 'ge', version_type='semver')"
+
 # TODO: pod-network-cidr can conflict locally check with IT to ensure correct range.
 - name: Run kubeadm init
   ansible.builtin.command: kubeadm init --config /etc/kubernetes/kubeadm-config.yaml --upload-certs
   tags:
     - install
+
+- name: Restore admin.conf
+  ansible.builtin.copy:
+    src: "/etc/kubernetes/admin.conf.bak"
+    dest: "/etc/kubernetes/admin.conf"
+  tags:
+    - install
+    - update
+  when:
+     kubernetes_version is version('1.29.0', 'ge', version_type='semver')"
 
 - name: Setup kubernetes .kube directory
   ansible.builtin.file:

--- a/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
+++ b/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
@@ -18,6 +18,8 @@
   tags:
     - install
     - update
+  when:
+    kubernetes_version is version('1.29.0', 'ge', version_type='semver')"
   block:
     - name: Back up admin.conf
       ansible.builtin.copy:
@@ -33,8 +35,6 @@
       tags:
         - install
         - update
-  when:
-     kubernetes_version is version('1.29.0', 'ge', version_type='semver')"
 
 # TODO: pod-network-cidr can conflict locally check with IT to ensure correct range.
 - name: Run kubeadm init
@@ -50,7 +50,7 @@
     - install
     - update
   when:
-     kubernetes_version is version('1.29.0', 'ge', version_type='semver')"
+    kubernetes_version is version('1.29.0', 'ge', version_type='semver')"
 
 - name: Setup kubernetes .kube directory
   ansible.builtin.file:

--- a/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
+++ b/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
@@ -13,7 +13,8 @@
     - install
     - update
 
-# TODO ADD DOC, workaround for https://github.com/kube-vip/kube-vip/issues/684
+# Workaround for https://github.com/kube-vip/kube-vip/issues/684 will be removed once
+# kube-vip releases a version with this fixed.
 - name: Update kube-vip.yaml to use super-admin.conf for kubeadm init in 1.29+
   ansible.builtin.replace:
     path: /etc/kubernetes/manifests/kube-vip.yaml
@@ -30,7 +31,8 @@
   tags:
     - install
 
-# TODO ADD DOC, workaround for https://github.com/kube-vip/kube-vip/issues/684
+# Workaround for https://github.com/kube-vip/kube-vip/issues/684 will be removed once
+# kube-vip releases a version with this fixed.
 - name: Restore kube-vip.yaml to use admin.conf for kubeadm init in 1.29+
   ansible.builtin.replace:
     path: /etc/kubernetes/manifests/kube-vip.yaml

--- a/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
+++ b/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
@@ -25,6 +25,7 @@
       ansible.builtin.copy:
         src: "/etc/kubernetes/admin.conf"
         dest: "/etc/kubernetes/admin.conf.bak"
+        remote_src: true
       tags:
         - install
         - update
@@ -32,6 +33,7 @@
       ansible.builtin.copy:
         src: "/etc/kubernetes/super-admin.conf"
         dest: "/etc/kubernetes/admin.conf"
+        remote_src: true
       tags:
         - install
         - update
@@ -46,6 +48,7 @@
   ansible.builtin.copy:
     src: "/etc/kubernetes/admin.conf.bak"
     dest: "/etc/kubernetes/admin.conf"
+    remote_src: true
   tags:
     - install
     - update

--- a/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
+++ b/roles/kubernetes/control_plane/init/primary/tasks/main.yaml
@@ -14,29 +14,13 @@
     - update
 
 # TODO ADD DOC, workaround for https://github.com/kube-vip/kube-vip/issues/684
-- name: Update admin.conf for K8s 1.29+
+- name: Update kube-vip.yaml to use super-admin.conf for kubeadm init in 1.29+
+  ansible.builtin.shell: >
+    sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml
+  when: kubernetes_version is version("1.29.0", "ge", version_type="semver")
   tags:
     - install
     - update
-  when:
-    kubernetes_version is version("1.29.0", "ge", version_type="semver")
-  block:
-    - name: Back up admin.conf
-      ansible.builtin.copy:
-        src: "/etc/kubernetes/admin.conf"
-        dest: "/etc/kubernetes/admin.conf.bak"
-        remote_src: true
-      tags:
-        - install
-        - update
-    - name: Replace admin with super.conf
-      ansible.builtin.copy:
-        src: "/etc/kubernetes/super-admin.conf"
-        dest: "/etc/kubernetes/admin.conf"
-        remote_src: true
-      tags:
-        - install
-        - update
 
 # TODO: pod-network-cidr can conflict locally check with IT to ensure correct range.
 - name: Run kubeadm init
@@ -44,16 +28,14 @@
   tags:
     - install
 
-- name: Restore admin.conf
-  ansible.builtin.copy:
-    src: "/etc/kubernetes/admin.conf.bak"
-    dest: "/etc/kubernetes/admin.conf"
-    remote_src: true
+# TODO ADD DOC, workaround for https://github.com/kube-vip/kube-vip/issues/684
+- name: Restore kube-vip.yaml to use admin.conf for kubeadm init in 1.29+
+  ansible.builtin.shell: >
+    sed -i 's#path: /etc/kubernetes/super-admin.conf#path: /etc/kubernetes/admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml
+  when: kubernetes_version is version("1.29.0", "ge", version_type="semver")
   tags:
     - install
     - update
-  when:
-    kubernetes_version is version('1.29.0', 'ge', version_type='semver')"
 
 - name: Setup kubernetes .kube directory
   ansible.builtin.file:

--- a/variables.tf
+++ b/variables.tf
@@ -297,7 +297,7 @@ variable "cluster_domain" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.27.11"
+  default = "1.28.7"
 }
 
 variable "cluster_cni" {


### PR DESCRIPTION
### Changes

* Updated the default `kubernetes_version`/`cluster_version` in the example files and doc to 1.28.7
* Updated the default `kubectl` version in the Dockerfile to 1.28.7 (currently the latest)

#### Notes:
There was an issue discovered with `kube-vip` and K8s 1.29+. In short kube-vip requires `super-admin.conf` permissions with Kubernetes 1.29 and without it, we run into issues setting up a new cluster with `kubeadm init`. 

`super-admin.conf` was introduced Kubernetes 1.29, and the user within that file is bound to the `system:masters` RBAC group. In previous kubernetes versions the `admin.conf` user was bound to this RBAC group, but now in 1.29 this user is bound to a new group called `kubeadm:cluster-admins` that has `cluster-admin` `ClusterRole` access.

If you take a look at the [1.29 Urgent Upgrade Notes
](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#urgent-upgrade-notes) from the kubernetes repo this change is described in more detail:

> `kubeadm`: a separate "super-admin.conf" file is now deployed. The User in `admin.conf` is now bound to a new RBAC Group `kubeadm:cluster-admins` that has `cluster-admin` `ClusterRole` access. The User in `super-admin.conf` is now bound to the `system:masters` built-in super-powers / break-glass Group that can bypass RBAC. Before this change, the default `admin.conf` was bound to `system:masters` Group, which was undesired. Executing `kubeadm init phase kubeconfig all` or just `kubeadm init` will now generate the new `super-admin.conf` file. The cluster admin can then decide to keep the file present on a node host or move it to a safe location. `kubadm certs renew` will renew the certificate in `super-admin.conf` to one year if the file exists; if it does not exist a "MISSING" note will be printed. `kubeadm upgrade apply` for this release will migrate this particular node to the two file setup. Subsequent kubeadm releases will continue to optionally renew the certificate in `super-admin.conf` if the file exists on disk and if renew on upgrade is not disabled. `kubeadm join --control-plane` will now generate only an `admin.conf` file that has the less privileged User.

At this point in time, `kube-vip` (even the latest versions) requires `super-admin.conf` with Kubernetes 1.29 during the initial `kubeadm init` phase and will fail without it as described in this GitHub issue here: https://github.com/kube-vip/kube-vip/issues/684. Our PR makes use of a workaround recommended in that GitHub issue where we're temporarily replacing the mounted kube conf file in the `kube-vip.yaml` manifest with `super-admin.conf` manifest before running  `kubeadm init` and then immediately replacing it with `admin.conf` after the command is run.

We will have to keep using the workaround for 1.29+ until a version of `kube-vip` is released that resolves this issue. After the fix is in place we can remove the workaround and point users to select a version of `kube-vip` with that particular fix for K8s 1.29+ installs. 

### Tests

| Scenario | Provider | K8s Version | kubectl | cluster_lb_type | Order  | Cadence   | Notes                                      |
|----------|----------|-------------|---------|-----------------|--------|-----------|--------------------------------------------|
| 1        | OSS      | 1.27.11     | 1.28.7  | kube_vip        |  | fast:2020 | OOTB                                       |
| 2        | OSS      | 1.28.7      | 1.28.7  | kube_vip        |  | fast:2020 | OOTB                                       |
| 3        | OSS      | 1.29.2      | 1.28.7  | kube_vip        |  | fast:2020 | OOTB - overwrite kubectl version in the DO |
| 4        | OSS      | 1.29.2      | 1.28.7  | metallb         |  | fast:2020 | OOTB - overwrite kubectl version in the DO |
