### PR TITLE
feat: (PSKD-408) (PSKD-513) Support K8s 1.30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 # Layers used for building/downloading/installing tools
 FROM baseline as tool_builder
 ARG HELM_VERSION=3.14.4
-ARG KUBECTL_VERSION=1.28.7
+ARG KUBECTL_VERSION=1.29.7
 ARG TERRAFORM_VERSION=1.8.5-*
 
 WORKDIR /build

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -69,9 +69,9 @@ Terraform input variables can be set in the following ways:
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| cluster_version        | Kubernetes version | string | "1.28.7" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
+| cluster_version        | Kubernetes version | string | "1.29.7" | Valid values are listed here: [SAS Viya platform Supported Kubernetes Versions](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n1ika6zxghgsoqn1mq4bck9dx695.htm#p03v0o4maa8oidn1awe0w4xlxcf6). |
 | cluster_cni            | Kubernetes container network interface (CNI) | string | "calico" | |
-| cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.27.2" | |
+| cluster_cni_version    | Kubernetes Container Network Interface (CNI) Version | string | "3.28.0" | |
 | cluster_cri            | Kubernetes container runtime interface (CRI) | string | "containerd" | |
 | cluster_cri_version    | Version of the CRI specifed by `cluster_cri` to be installed  | string | "1.6.28" | Set as an empty string to use the latest upstream version from the Docker APT repository. Currently only containerd is supported, see the [releases page](https://github.com/containerd/containerd/releases) for available versions |
 | cluster_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |
@@ -353,11 +353,11 @@ The following variables are used to describe the machine targets for the SAS Viy
 | prefix | A prefix used in the names of all the resources created by this script | string | | |
 | deployment_type | Type of deployment to be performed | string | "bare_metal" | Specify `bare_metal` or `vsphere`. |
 | kubernetes_cluster_name | Cluster name | string | "{{ prefix }}-oss" | This item is auto-filled. **ONLY** change the `prefix` value described previously. |
-| kubernetes_version | Kubernetes version | string | "1.28.7" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
+| kubernetes_version | Kubernetes version | string | "1.29.7" | Valid values are listed here: [Kubernetes Releases](https://kubernetes.io/releases/). |
 | kubernetes_upgrade_allowed | | bool | true | **NOTE:** Not currently used. |
 | kubernetes_arch | | string | "{{ vm_arch }}" | This item is auto-filled. **ONLY** change the `vm_arch` value described previously. |
 | kubernetes_cni | Kubernetes Container Network Interface (CNI) | string | "calico" | |
-| kubernetes_cni_version | Kubernetes Container Network Interface (CNI) Version | string | "3.27.2" | |
+| kubernetes_cni_version | Kubernetes Container Network Interface (CNI) Version | string | "3.28.0" | |
 | kubernetes_cri | Kubernetes Container Runtime Interface (CRI) | string | "containerd" | |
 | kubernetes_cri_version | Version of the CRI specifed by `kubernetes_cri` to be installed  | string | "1.6.28" | Set as an empty string to use the latest upstream version from the Docker APT repository. Currently only containerd is supported, see the [releases page](https://github.com/containerd/containerd/releases) for available versions | |
 | kubernetes_service_subnet | Kubernetes service subnet | string | "10.43.0.0/16" | |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -213,9 +213,9 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh" # Directory holding public keys to be used on each machine
 
 # Kubernetes - Cluster
-cluster_version        = "1.28.7"                       # Kubernetes version
+cluster_version        = "1.29.7"                       # Kubernetes version
 cluster_cni            = "calico"                        # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.27.2"                        # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.28.0"                        # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"                    # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.28"                        # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.35.0.0/16"                  # Kubernetes service subnet
@@ -520,7 +520,7 @@ kubernetes_version         : ""
 kubernetes_upgrade_allowed : true
 kubernetes_arch            : "{{ vm_arch }}"
 kubernetes_cni             : "calico"           # Choices : [calico]
-kubernetes_cni_version     : "3.27.2"           # Choices : [3.27.2]
+kubernetes_cni_version     : "3.28.0"           # Choices : [3.28.0]
 kubernetes_cri             : "containerd"       # Choices : [containerd]
 kubernetes_cri_version     : "1.6.28"           # Choices : [1.6.28]
 kubernetes_service_subnet  : ""

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -53,7 +53,7 @@ Example of using build arguments to control specific versions of dependencies in
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg KUBECTL_VERSION=1.28.7 \
+	--build-arg KUBECTL_VERSION=1.29.7 \
 	-t viya4-iac-k8s .
 ```
 

--- a/examples/bare-metal/sample-ansible-vars.yaml
+++ b/examples/bare-metal/sample-ansible-vars.yaml
@@ -24,7 +24,7 @@ kubernetes_version         : ""
 kubernetes_upgrade_allowed : true
 kubernetes_arch            : "{{ vm_arch }}"
 kubernetes_cni             : "calico"        # Choices : [calico]
-kubernetes_cni_version     : "3.27.2"        # Choices : [3.27.2]
+kubernetes_cni_version     : "3.28.0"        # Choices : [3.28.0]
 kubernetes_cri             : "containerd"    # Choices : [containerd]
 kubernetes_cri_version     : "1.6.28"        # Choices : [1.6.28]
 kubernetes_service_subnet  : ""

--- a/examples/vsphere/sample-terraform-dhcp.tfvars
+++ b/examples/vsphere/sample-terraform-dhcp.tfvars
@@ -18,9 +18,9 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.28.7"      # Kubernetes Version
+cluster_version        = "1.29.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.28.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.28"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-minimal.tfvars
+++ b/examples/vsphere/sample-terraform-minimal.tfvars
@@ -18,9 +18,9 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.28.7"      # Kubernetes Version
+cluster_version        = "1.29.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.28.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.28"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-static-ips.tfvars
+++ b/examples/vsphere/sample-terraform-static-ips.tfvars
@@ -18,9 +18,9 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.28.7"      # Kubernetes Version
+cluster_version        = "1.29.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.28.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.28"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-static-singlestore.tfvars
+++ b/examples/vsphere/sample-terraform-static-singlestore.tfvars
@@ -18,9 +18,9 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.28.7"      # Kubernetes Version
+cluster_version        = "1.29.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.28.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.28"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/examples/vsphere/sample-terraform-vi.tfvars
+++ b/examples/vsphere/sample-terraform-vi.tfvars
@@ -18,9 +18,9 @@ vsphere_network       = "" # Name of the network to to use for the VMs
 system_ssh_keys_dir = "~/.ssh/oss" # Directory holding public keys to be used on each system
 
 # Kubernetes - Cluster
-cluster_version        = "1.28.7"      # Kubernetes Version
+cluster_version        = "1.29.7"      # Kubernetes Version
 cluster_cni            = "calico"       # Kubernetes Container Network Interface (CNI)
-cluster_cni_version    = "3.27.2"       # Kubernetes Container Network Interface (CNI) Version
+cluster_cni_version    = "3.28.0"       # Kubernetes Container Network Interface (CNI) Version
 cluster_cri            = "containerd"   # Kubernetes Container Runtime Interface (CRI)
 cluster_cri_version    = "1.6.28"       # Kubernetes Container Runtime Interface (CRI) Version
 cluster_service_subnet = "10.43.0.0/16" # Kubernetes Service Subnet

--- a/variables.tf
+++ b/variables.tf
@@ -297,7 +297,7 @@ variable "cluster_domain" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.28.7"
+  default = "1.29.7"
 }
 
 variable "cluster_cni" {
@@ -307,7 +307,7 @@ variable "cluster_cni" {
 
 variable "cluster_cni_version" {
   type    = string
-  default = "3.27.2"
+  default = "3.28.0"
 }
 
 variable "cluster_cri" {


### PR DESCRIPTION
### Changes

* Updated the default `kubernetes_version` in the example files to 1.29.7
* Updated the default `kubectl` version in the Dockerfile to 1.29.7
* Bump calico version to 3.28.0

### Tests

| Scenario | Provider | Cluster Version | kubectl Version | Order  | Cadence   | Notes                                      |
|----------|----------|-----------------|-----------------|--------|-----------|--------------------------------------------|
| 1        | OSS      | v1.29.7         | v1.29.7         | * | fast:2020 | OOTB                                       |
| 2        | OSS      | v1.30.3         | v1.29.7         | * | fast:2020 | OOTB - overwrite kubectl version in the DO |
| 3        | OSS      | v1.28.11        | v1.29.7         | *| fast:2020 | OOTB                                       |
