### PR TITLE
chore: (PSKD-1405) Dependency Version Bumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 
 # Layers used for building/downloading/installing tools
 FROM baseline AS tool_builder
-ARG HELM_VERSION=3.16.2
-ARG KUBECTL_VERSION=1.30.8
-ARG TERRAFORM_VERSION=1.9.8-*
+ARG HELM_VERSION=3.17.1
+ARG KUBECTL_VERSION=1.30.10
+ARG TERRAFORM_VERSION=1.10.5-*
 
 WORKDIR /build
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -14,6 +14,7 @@ For dependency installation instructions and sources, links have been provided i
 | ~              | [kubectl](https://kubernetes.io/docs/tasks/tools/)                                                                                             | 1.28 - 1.30 |
 | ~              | [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)                                                                           | any         |
 | ~              | [jq](https://jqlang.github.io/jq/download/)                                                                                                    | >=1.6       |
+| ~              | [sshpass](https://manpages.ubuntu.com/manpages/jammy/man1/sshpass.1.html)                                                                                                    | >=1.09       |
 | pip            | ansible-core                                                                                                                                   | 2.16.4      |
 | pip            | openshift                                                                                                                                      | 0.13.2      |
 | pip            | kubernetes                                                                                                                                     | 27.2.0      |


### PR DESCRIPTION
Bumping several versions to address security vulnerabilities. Docker image users will need to build the image using the latest changes to get the new versions. Consumers who use local tooling will need to update the versions themselves. I've also added a required dependency that was missing from the Dependencies.md doc. 

**Tool updates:**
* `kubectl`: 1.30.8 -> 1.30.10
* `terraform`: 1.9.8 -> 1.10.5
* `helm`: 3.16.2 -> 3.17.1

# Testing
|Scenario|Method |K8s version|order |cadence|Notes|
|-|-|-|-|-|-|
|1  |terraform 1.10.5 inside docker container |1.30.10      |***   |  stable: 2025.02 |Cluster created successfully with the updated versions indicated in the Changes above. Successful Viya deployment with all pods reaching Running and stable.|
|2   |terraform 1.10.5 using local tooling |1.30.10      |n/a|n/a| Cluster created successfully with the updated versions indicated in the Changes above. No Viya deployment|