### PR TITLE
ci: Create dependabot.yml for dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,4 @@ updates:
       interval: "weekly"
     target-branch: "staging"
     open-pull-requests-limit: 2
+    

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,4 +31,4 @@ updates:
       interval: "weekly"
     target-branch: "staging"
     open-pull-requests-limit: 2
-    
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,4 +31,3 @@ updates:
       interval: "weekly"
     target-branch: "staging"
     open-pull-requests-limit: 2
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Terraform dependencies
+  - package-ecosystem: "terraform"
+    directory: "/"  # The directory where your Terraform files are located
+    schedule:
+      interval: "weekly"
+    target-branch: "staging"
+    open-pull-requests-limit: 2
+
+  # Docker dependencies
+  - package-ecosystem: "docker"
+    directory: "/"  # The directory where your Dockerfile is located
+    schedule:
+      interval: "weekly"
+    target-branch: "staging"
+    open-pull-requests-limit: 2
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"  # The directory where your GitHub Actions workflows are located
+    schedule:
+      interval: "weekly"
+    target-branch: "staging"
+    open-pull-requests-limit: 2
+
+  # Python dependencies (from requirements.txt)
+  - package-ecosystem: "pip"
+    directory: "/"  # The directory where your requirements.txt is located
+    schedule:
+      interval: "weekly"
+    target-branch: "staging"
+    open-pull-requests-limit: 2
+


### PR DESCRIPTION
This dependabot.yml configuration file is designed to keep dependencies up to date by automatically scanning and managing dependencies for Terraform modules, Docker, GitHub Actions, and Python (via pip). It will open pull requests automatically whenever there are updates available for these dependencies.

Additionally, this setup can be extended to trigger tests in GitHub Actions as part of the pull request process. This allows the project to be tested automatically with the updated versions of the dependencies, ensuring compatibility.

To prevent maintainers from being overwhelmed, the configuration limits the number of pull requests created in a single run. Currently, the limit is set to 2 pull requests per dependency scope. This applies across Terraform, Docker, GitHub Actions, and Python (pip) dependencies, ensuring that the updates are manageable and not too frequent.