### PR TITLE
docs: update README to suggest release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,14 @@ Run the following commands from a terminal session:
 
 ```bash
 # clone this repo
-git clone https://github.com/sassoftware/viya4-iac-k8s
+git clone -b <release-version-tag> https://github.com/sassoftware/viya4-iac-k8s
 
 # move to the project directory
 cd viya4-iac-k8s
 ```
+**NOTE:** To obtain a tagged release version of this project, always refer to the desired release version tag when cloning this repository as shown above. Alternatively, you can `git checkout <tag>` the tagged release version if you've already cloned the repository without a tag. 
+
+You can find the latest release version in the [releases page](https://github.com/sassoftware/viya4-iac-k8s/releases).
 
 ### Customize Input Values
 


### PR DESCRIPTION
This PR updates to use a specific tagged release of the viya4-iac-k8s module, instead of referencing the main branch.