### PR TITLE
fix: ensure conntrack installed

### DIFF
--- a/roles/kubernetes/common/tasks/main.yaml
+++ b/roles/kubernetes/common/tasks/main.yaml
@@ -123,6 +123,7 @@
   vars:
     packages:
       - sshpass
+      - conntrack
   tags:
     - install
     - update


### PR DESCRIPTION
As reported in #171 conntrack is unavailable in some Ubuntu 24.04 distributions