### PR TITLE
feat: bump metrics-server to 3.13.0 and local-static-provisioner to 2.8.0 (PSCLOUD-63)

### DIFF
--- a/roles/kubernetes/metrics/metrics-server/defaults/main.yaml
+++ b/roles/kubernetes/metrics/metrics-server/defaults/main.yaml
@@ -7,7 +7,7 @@ kubernetes_METRICS_SERVER_NAME: metrics-server
 kubernetes_METRICS_SERVER_NAMESPACE: kube-system
 kubernetes_METRICS_SERVER_CHART_NAME: metrics-server
 kubernetes_METRICS_SERVER_CHART_URL: https://kubernetes-sigs.github.io/metrics-server/
-kubernetes_METRICS_SERVER_CHART_VERSION: 3.12.0
+kubernetes_METRICS_SERVER_CHART_VERSION: 3.13.0
 kubernetes_METRICS_SERVER_CONFIG:
   apiService:
     create: true

--- a/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
+++ b/roles/kubernetes/storage/sig-storage-local-static-provisioner/defaults/main.yaml
@@ -7,7 +7,7 @@ kubernetes_LOCAL_VOLUME_NAME: sig-storage-local-static-provisioner-sas
 kubernetes_LOCAL_VOLUME_NAMESPACE: kube-system
 kubernetes_LOCAL_VOLUME_CHART_NAME: Chart.yaml
 kubernetes_LOCAL_VOLUME_REPO: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner.git
-kubernetes_LOCAL_VOLUME_CHART_VERSION: 2.6.0
+kubernetes_LOCAL_VOLUME_CHART_VERSION: 2.8.0
 kubernetes_LOCAL_VOLUME_REPO_VERSION: "v{{ kubernetes_LOCAL_VOLUME_CHART_VERSION }}"
 kubernetes_LOCAL_VOLUME_REPO_LOCATION: "/tmp/{{ kubernetes_LOCAL_VOLUME_NAME }}"
 kubernetes_LOCAL_VOLUME_CONFIG:


### PR DESCRIPTION
- Updated METRICS_SERVER_CHART_VERSION from 3.12.0 to 3.13.0
- Updated KUBERNETES_LOCAL_VOLUME_CHART_VERSION from 2.6.0 to 2.8.0