### PR TITLE
fix: install operator fails

### DIFF
--- a/roles/kubernetes/cni/calico/tasks/main.yaml
+++ b/roles/kubernetes/cni/calico/tasks/main.yaml
@@ -14,6 +14,8 @@
   tags:
     - install
     - update
+  retries: 10
+  delay: 10
 
 # Wait for Tigera CRDs to be available
 # - name: Wait for Tigera CRDs to be registered


### PR DESCRIPTION
Fixes first time failure of install operator when cluster is not ready as per #172