### PR TITLE
fix: failures on re-run

### DIFF
--- a/roles/kubernetes/cni/calico/tasks/main.yaml
+++ b/roles/kubernetes/cni/calico/tasks/main.yaml
@@ -9,8 +9,8 @@
 #
 - name: Install Operator
   ansible.builtin.shell: |
-    kubectl create -f "https://raw.githubusercontent.com/projectcalico/calico/v{{ kubernetes_cni_version }}/manifests/operator-crds.yaml" && \
-    kubectl create -f "https://raw.githubusercontent.com/projectcalico/calico/v{{ kubernetes_cni_version }}/manifests/tigera-operator.yaml"
+    kubectl apply --server-side -f "https://raw.githubusercontent.com/projectcalico/calico/v{{ kubernetes_cni_version }}/manifests/operator-crds.yaml" && \
+    kubectl apply --server-side -f "https://raw.githubusercontent.com/projectcalico/calico/v{{ kubernetes_cni_version }}/manifests/tigera-operator.yaml"
   tags:
     - install
     - update
@@ -41,7 +41,7 @@
 
 - name: Apply custom-resources
   ansible.builtin.shell: |
-    kubectl create -f /tmp/custom-resources.yaml
+    kubectl apply -f /tmp/custom-resources.yaml
   tags:
     - install
     - update


### PR DESCRIPTION
Re-running the playbook fails as we use kubectl create. Instead we should use apply as this follows ansible's guideline of re-runs being idempotent.