### PR TITLE
fix: errors on containerd uninstall

### DIFF
--- a/roles/kubernetes/cri/containerd/tasks/main.yaml
+++ b/roles/kubernetes/cri/containerd/tasks/main.yaml
@@ -22,6 +22,8 @@
       - containerd
       - containerd.io
       - runc
+  retries: 5
+  delay: 3
   ignore_errors: true
   tags:
     - install


### PR DESCRIPTION
The package lock can sometimes still be held by the time the next step occurs, we should retry instead.