### PR TITLE
feat: explictly fail if ubuntu version is incorrect

### DIFF
--- a/roles/kubernetes/common/tasks/main.yaml
+++ b/roles/kubernetes/common/tasks/main.yaml
@@ -2,6 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Verify Ubuntu version is supported
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution == "Ubuntu"
+      - ansible_distribution_version in ["22.04", "24.04"]
+    fail_msg: "Unsupported OS: {{ ansible_distribution }} {{ ansible_distribution_version }}. Only Ubuntu 22.04 and 24.04 are supported."
+    success_msg: "OS version check passed: {{ ansible_distribution }} {{ ansible_distribution_version }}"
+  tags:
+    - install
+    - update
+
 - name: Add ssh keys - root user
   ansible.posix.authorized_key:
     user: root

--- a/roles/kubernetes/cri/containerd/tasks/main.yaml
+++ b/roles/kubernetes/cri/containerd/tasks/main.yaml
@@ -88,7 +88,6 @@
     url: https://download.docker.com/linux/ubuntu/gpg
     keyring: /usr/share/keyrings/docker-archive-keyring.gpg
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -97,7 +96,6 @@
   ansible.builtin.apt_repository:
     repo: deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -119,7 +117,6 @@
   vars:
     packages:
       - "containerd.io{% if kubernetes_cri_version is defined and kubernetes_cri_version %}={{ kubernetes_cri_version }}{{ kubernetes_cri_deb_rev }}{%endif %}"
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -135,7 +132,6 @@
 #   vars:
 #     packages:
 #     - containerd
-#   when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
 #   tags:
 #     - install
 #     - update

--- a/roles/kubernetes/cri/cri-o/tasks/main.yaml
+++ b/roles/kubernetes/cri/cri-o/tasks/main.yaml
@@ -29,7 +29,6 @@
 - name: Setting cri-o facts
   set_fact:
     k8s_version_semantic_parts: "{{ kubernetes_version.split('.') }}"
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -40,7 +39,6 @@
     k8s_major_version: "{% if k8s_version_semantic_parts|length > 0 %}{{ k8s_version_semantic_parts.0 }}{% endif %}"
     k8s_minor_version: "{% if k8s_version_semantic_parts|length > 1 %}{{ k8s_version_semantic_parts.1 }}{% endif %}"
     k8s_patch_version: "{% if k8s_version_semantic_parts|length > 2 %}{{ k8s_version_semantic_parts.2 }}{% else %}0{% endif %}"
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -50,7 +48,6 @@
     url: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/{{ os }}/Release.key
     keyring: /usr/share/keyrings/libcontainers-archive-keyring.gpg
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -60,7 +57,6 @@
     url: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ k8s_major_version }}.{{ k8s_minor_version }}/{{ os }}/Release.key
     keyring: /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -73,7 +69,6 @@
   with_items:
     - deb [signed-by=/usr/share/keyrings/libcontainers-archive-keyring.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/{{ os }}/ /
     - deb [signed-by=/usr/share/keyrings/libcontainers-crio-archive-keyring.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ k8s_major_version }}.{{ k8s_minor_version }}/{{ os }}/ /
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -127,7 +122,6 @@
     packages:
       - cri-o
       - cri-o-runc
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/kubernetes/cri/docker/tasks/main.yaml
+++ b/roles/kubernetes/cri/docker/tasks/main.yaml
@@ -48,7 +48,6 @@
     url: https://download.docker.com/linux/ubuntu/gpg
     keyring: /usr/share/keyrings/docker-archive-keyring.gpg
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -58,7 +57,6 @@
   ansible.builtin.apt_repository:
     repo: deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/kubernetes/node/baseline/tasks/main.yaml
+++ b/roles/kubernetes/node/baseline/tasks/main.yaml
@@ -8,7 +8,6 @@
     name: nfs-common
     state: present
     update_cache: true
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -18,7 +17,6 @@
   ansible.builtin.set_fact:
     owner: nobody
     group: nogroup
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/kubernetes/toolbox/tasks/main.yaml
+++ b/roles/kubernetes/toolbox/tasks/main.yaml
@@ -40,7 +40,6 @@
   ansible.builtin.get_url:
     url: "https://pkgs.k8s.io/core:/stable:/v{{ k8s_major_version }}.{{ k8s_minor_version }}/deb/Release.key"
     dest: /etc/apt/keyrings/kubernetes-apt-keyring.asc
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -51,7 +50,6 @@
     repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v{{ k8s_major_version }}.{{ k8s_minor_version }}/deb/ /"
     state: present
     update_cache: true
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -124,7 +122,6 @@
       - kubectl={{ kubernetes_version }}-{{ kube_deb_rev }}
     state: present
     update_cache: true
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
 
@@ -137,7 +134,6 @@
     - kubelet
     - kubeadm
     - kubectl
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
 
@@ -149,7 +145,6 @@
     - kubelet
     - kubeadm
     - kubectl
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - uninstall
 
@@ -161,7 +156,6 @@
       - kubectl={{ kubernetes_version }}-{{ kube_deb_rev }}
     state: absent
     update_cache: true
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - uninstall
 

--- a/roles/systems/bare_metal/init/tasks/main.yaml
+++ b/roles/systems/bare_metal/init/tasks/main.yaml
@@ -2,12 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Verify Ubuntu version is supported
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution == "Ubuntu"
+      - ansible_distribution_version in ["22.04", "24.04"]
+    fail_msg: "Unsupported OS: {{ ansible_distribution }} {{ ansible_distribution_version }}. Only Ubuntu 22.04 and 24.04 are supported."
+    success_msg: "OS version check passed: {{ ansible_distribution }} {{ ansible_distribution_version }}"
+  tags:
+    - install
+    - update
+
 # NOTE: Should make this more generic for other OS types
 - name: Set owner and group for Ubuntu OS
   ansible.builtin.set_fact:
     owner: nobody
     group: nogroup
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/systems/common/tasks/main.yaml
+++ b/roles/systems/common/tasks/main.yaml
@@ -103,7 +103,6 @@
     - python3-dev
     - python3-pip
     - nfs-common
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -112,7 +111,6 @@
   ansible.builtin.shell: |
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -121,7 +119,6 @@
   ansible.builtin.shell: |
     swapoff -a
     sed -i '/swap/d' /etc/fstab
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/systems/container_registry/harbor/tasks/main.yaml
+++ b/roles/systems/container_registry/harbor/tasks/main.yaml
@@ -48,7 +48,6 @@
     url: https://download.docker.com/linux/ubuntu/gpg
     keyring: /usr/share/keyrings/docker-archive-keyring.gpg
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -58,7 +57,6 @@
   ansible.builtin.apt_repository:
     repo: deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -105,7 +103,6 @@
   with_items:
     - devops
     - ubuntu
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/systems/control_plane/tasks/main.yaml
+++ b/roles/systems/control_plane/tasks/main.yaml
@@ -8,7 +8,6 @@
     name: nfs-common
     state: present
     update_cache: true
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/systems/jump_server/tasks/main.yaml
+++ b/roles/systems/jump_server/tasks/main.yaml
@@ -12,7 +12,6 @@
   ansible.builtin.set_fact:
     owner: nobody
     group: nogroup
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -21,7 +20,6 @@
   ansible.builtin.package:
     name: nfs-common
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/systems/nfs_server/tasks/main.yaml
+++ b/roles/systems/nfs_server/tasks/main.yaml
@@ -9,7 +9,6 @@
   with_items:
     - nfs-kernel-server
     - rpcbind
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -26,7 +25,6 @@
         owner: nobody
         group: nogroup
         mode: "0777"
-      when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
 
     - name: Test for export mount point
       ansible.builtin.shell: grep -c "^/export" /etc/exports || true
@@ -59,7 +57,6 @@
         owner: nobody
         group: nogroup
         mode: "0777"
-      when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
 
     - name: Test for /pvs export mount point
       ansible.builtin.shell: grep -c "^/pvs" /etc/exports || true
@@ -92,7 +89,6 @@
         owner: nobody
         group: nogroup
         mode: "0777"
-      when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
 
     - name: Test for export mount point
       ansible.builtin.shell: grep -c "^/srv/nfs/kubernetes/sc/default" /etc/exports || true
@@ -139,21 +135,18 @@
       echo "Directory structure created successfully for namespace: $NAMESPACE"
       echo "  /export/$NAMESPACE/{bin,data,homes,astores}"
       echo "  /pvs/$NAMESPACE/{bin,data,homes,astores}"
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
 
 - name: Create default viya4 namespace directories
   ansible.builtin.command: /usr/local/bin/create-namespace-dirs.sh viya4
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
 
 - name: Export file system
   ansible.builtin.command: exportfs -a
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -167,7 +160,6 @@
     - nfs-server
     - portmap
     - rpc-statd
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/systems/postgres/install/tasks/main.yaml
+++ b/roles/systems/postgres/install/tasks/main.yaml
@@ -7,7 +7,6 @@
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     keyring: /usr/share/keyrings/postgres-archive-keyring.gpg
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update
@@ -16,7 +15,6 @@
   ansible.builtin.apt_repository:
     repo: deb [arch=amd64 signed-by=/usr/share/keyrings/postgres-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main
     state: present
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update

--- a/roles/systems/vsphere/init/tasks/main.yaml
+++ b/roles/systems/vsphere/init/tasks/main.yaml
@@ -37,7 +37,6 @@
   ansible.builtin.set_fact:
     owner: nobody
     group: nogroup
-  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version == "24.04" or ansible_distribution_version == "22.04")
   tags:
     - install
     - update


### PR DESCRIPTION
Some tasks will run and some will be skipped if the version is incorrect. We shoudl explictly check that the ubuntu version is correct at the start of each play.

We should also consider removing the version checks from each command to reduce runtime. In #175 there's a large number of replacements we could do. 