### PR TITLE
fix: utilize ansible galaxy cache

### DIFF
--- a/oss-k8s.sh
+++ b/oss-k8s.sh
@@ -88,7 +88,7 @@ gather_ans_creds() {
 # vSphere and bare-metal items
 ansible_prep() {
     gather_ans_creds
-    ansible-galaxy collection install -r "$BASEDIR/requirements.yaml" -f
+    ansible-galaxy collection install -r "$BASEDIR/requirements.yaml"
 }
 
 clean_up() {


### PR DESCRIPTION
Improves run-time of subsequent runs.

Force is un-neccessary as we are already pinning the version numbers in requirements.yaml so the script will ensure the correct versions of the dependencies are installed.

On slow networks this can increase runtime signficantly. 