### PR TITLE
chore: remove unused inventory group

### DIFF
--- a/examples/bare-metal/sample-inventory
+++ b/examples/bare-metal/sample-inventory
@@ -76,5 +76,4 @@ postgres_system_setting_max_connections="1024"
 k8s
 jump
 nfs
-cr
 postgres

--- a/examples/bare-metal/sample-inventory-internal-postgres
+++ b/examples/bare-metal/sample-inventory-internal-postgres
@@ -60,4 +60,3 @@ nfs_server
 k8s
 jump
 nfs
-cr


### PR DESCRIPTION
CR was removed in a previous commit but there remains a reference which causes warnings at the bottom of the samples