### PR TITLE
fix: node removal can hang indefinitely

### DIFF
--- a/roles/kubernetes/node/removal/tasks/main.yaml
+++ b/roles/kubernetes/node/removal/tasks/main.yaml
@@ -4,7 +4,7 @@
 ---
 - name: Draining the node
   ansible.builtin.shell: |
-    kubectl drain {{ ansible_hostname }} --delete-emptydir-data --force --ignore-daemonsets
+    kubectl drain {{ ansible_hostname }} --delete-emptydir-data --force --ignore-daemonsets --timeout 60
   delegate_to: "{{ groups['k8s_control_plane'][0] }}"
   ignore_errors: true
   tags:


### PR DESCRIPTION
The drain command can hang if the cluster is not healthy. Set a timeout to allow the uninstall to continue.