### PR TITLE
fix: clean up CNI configuration between installs

### DIFF
--- a/roles/kubernetes/node/removal/tasks/main.yaml
+++ b/roles/kubernetes/node/removal/tasks/main.yaml
@@ -17,6 +17,13 @@
   tags:
     - uninstall
 
+- name: Remove CNI configuration
+  ansible.builtin.file:
+    state: absent
+    path: /etc/cni/net.d
+  tags:
+    - uninstall
+
 - name: Clean up IPTables
   ansible.builtin.shell: |
     iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X


### PR DESCRIPTION
Related to #185. As per the kubeadm docuementation we should remove the cni configuration during uninstall

Kubeadm documentation lists it here:
https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-reset/#cleanup-of-cni-configuration