### PR TITLE
fix: containerd downgrades cause failures

### DIFF
--- a/roles/kubernetes/cri/containerd/tasks/main.yaml
+++ b/roles/kubernetes/cri/containerd/tasks/main.yaml
@@ -116,6 +116,7 @@
   ansible.builtin.package:
     name: "{{ packages }}"
     state: present
+    allow_downgrade: true
   vars:
     packages:
       - "containerd.io{% if kubernetes_cri_version is defined and kubernetes_cri_version %}={{ kubernetes_cri_version }}{{ kubernetes_cri_deb_rev }}{%endif %}"


### PR DESCRIPTION
Configured containerd versions lower than what is installed will cause failures in the install process. This addresses #187