### PR TITLE
fix: cannot downgrade kubernetes version

### DIFF
--- a/roles/kubernetes/toolbox/tasks/main.yaml
+++ b/roles/kubernetes/toolbox/tasks/main.yaml
@@ -122,6 +122,8 @@
       - kubectl={{ kubernetes_version }}-{{ kube_deb_rev }}
     state: present
     update_cache: true
+    allow_downgrade: true
+    allow_change_held_packages: true
   tags:
     - install
 
@@ -156,6 +158,8 @@
       - kubectl={{ kubernetes_version }}-{{ kube_deb_rev }}
     state: absent
     update_cache: true
+    allow_change_held_packages: true
+    allow_downgrade: true
   tags:
     - uninstall
 

--- a/roles/systems/common/tasks/main.yaml
+++ b/roles/systems/common/tasks/main.yaml
@@ -106,6 +106,8 @@
   tags:
     - install
     - update
+  retries: 3
+  delay: 3
 
 - name: Update alternatives for Python and PIP
   ansible.builtin.shell: |


### PR DESCRIPTION
Uninstall fails if kubernetes version is downgraded after failed deployment.