### PR TITLE
fix: kube-proxy collides with kubevip

### DIFF
--- a/roles/kubernetes/control_plane/init/primary/templates/kubeadm-config.j2
+++ b/roles/kubernetes/control_plane/init/primary/templates/kubeadm-config.j2
@@ -72,6 +72,14 @@ kind: KubeProxyConfiguration
 mode: "ipvs"
 ipvs:
   strictARP: true
+{% if kubernetes_loadbalancer == "kube_vip" %}
+  excludeCIDRs:
+{% for item in kubernetes_loadbalancer_addresses %}
+{% for key, value in item.items() %}
+  - "{{ value }}"
+{% endfor %}
+{% endfor %}
+{% endif %}
 metricsBindAddress: "0.0.0.0:10249"
 enableProfiling: true
 clusterCIDR: "{{ kubernetes_pod_subnet }}"

--- a/roles/kubernetes/loadbalancer/kube_vip/templates/kube-vip-cm.tmpl
+++ b/roles/kubernetes/loadbalancer/kube_vip/templates/kube-vip-cm.tmpl
@@ -5,6 +5,10 @@ metadata:
   name: kubevip
   namespace: kube-system
 data:
+  {
 {% for address in kubernetes_loadbalancer_addresses %}
-  {{ address }}
+{% for key, value in address.items() %}
+   '{{ key }}': '{{ value }}',
 {% endfor %}
+{% endfor %}
+  }


### PR DESCRIPTION
As raised in #192. Kube-proxy will remove networking configuration for it's pod CIDR that it does not manage. In the instances where our kube_vip_loadbalancer CIDR overlaps with the pod CIDR this will cause failures to provision a virtual IP for Loadbalancers.

See: https://kube-vip.io/docs/about/architecture/#known-issues