### PR TITLE
fix: errors with multiple kube-vip lbs and timeout syntax

### DIFF
--- a/roles/kubernetes/loadbalancer/kube_vip/templates/kube-vip-cm.tmpl
+++ b/roles/kubernetes/loadbalancer/kube_vip/templates/kube-vip-cm.tmpl
@@ -5,6 +5,14 @@ metadata:
   name: kubevip
   namespace: kube-system
 data:
+{% if kubernetes_loadbalancer == "kube_vip" %}
+{% for address in kubernetes_loadbalancer_addresses %}
+{% for key, value in address.items() %}
+  {{ key }}: {{ value }}
+{% endfor %}
+{% endfor %}
+{% else %}
 {% for address in kubernetes_loadbalancer_addresses %}
   {{ address }}
 {% endfor %}
+{% endif %}

--- a/roles/kubernetes/node/removal/tasks/main.yaml
+++ b/roles/kubernetes/node/removal/tasks/main.yaml
@@ -4,7 +4,7 @@
 ---
 - name: Draining the node
   ansible.builtin.shell: |
-    kubectl drain {{ ansible_hostname }} --delete-emptydir-data --force --ignore-daemonsets --timeout 60
+    kubectl drain {{ ansible_hostname }} --delete-emptydir-data --force --ignore-daemonsets --timeout 60s
   delegate_to: "{{ groups['k8s_control_plane'][0] }}"
   ignore_errors: true
   tags:


### PR DESCRIPTION
* Resolve timeout syntax eror on newer versions of kubectl/k8s
* Correctly populate multiple load balancer CIDRs for Kube-vip
Resolves: https://github.com/sassoftware/viya4-iac-k8s/issues/198