### PR TITLE
docs: update Kubernetes supported versions to 1.31-1.33 (PSCLOUD-1021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - [Additional Resources](#additional-resources)
 
 ## Kubernetes Support
-At this time, the viya4-iac-k8s project supports Kubernetes versions 1.29 through 1.31. Support for Kubernetes 1.32 is to be determined.
+At this time, the viya4-iac-k8s project supports Kubernetes versions 1.31 through 1.33.
 
 ## Release Notes
 


### PR DESCRIPTION
The README was incorrectly stating support for K8s 1.29-1.31 with 1.32 TBD. Per v3.16.0 release notes and code in sample-ansible-vars.yaml, the project now supports Kubernetes versions 1.31.x through 1.33.x.

Fixes: https://github.com/sassoftware/viya4-iac-k8s/issues/210